### PR TITLE
Deploy Kernel without using the Meta Factory

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "lodash": "^4.17.21",
     "mongoose": "^8.5.0",
     "nestjs-pino": "^4.1.0",
-    "permissionless": "^0.2.11",
+    "permissionless": "^0.2.33",
     "pino-http": "^10.2.0",
     "redlock": "^5.0.0-beta.2",
     "reflect-metadata": "^0.2.0",

--- a/src/transaction/smart-wallets/kernel/create.kernel.account.ts
+++ b/src/transaction/smart-wallets/kernel/create.kernel.account.ts
@@ -1,12 +1,18 @@
 import {
+  Account,
+  Chain,
   createPublicClient,
   createWalletClient,
   decodeFunctionData,
   decodeFunctionResult,
   encodeFunctionData,
   Hex,
+  LocalAccount,
+  OneOf,
   parseAbi,
   publicActions,
+  Transport,
+  WalletClient,
   zeroAddress,
 } from 'viem'
 import { KernelAccountClientConfig } from './kernel-account.config'
@@ -15,14 +21,18 @@ import {
   KernelAccountActions,
   KernelAccountClient,
 } from './kernel-account.client'
+import { EthereumProvider } from 'permissionless/utils/toOwner'
 import { KernelVersion, toEcdsaKernelSmartAccount } from 'permissionless/accounts'
 
 export type entryPointV_0_7 = '0.7'
 
 export async function createKernelAccountClient<
   entryPointVersion extends '0.6' | '0.7' = entryPointV_0_7,
+  owner extends OneOf<
+    EthereumProvider | WalletClient<Transport, Chain | undefined, Account> | LocalAccount
+  > = LocalAccount,
 >(
-  parameters: KernelAccountClientConfig<entryPointVersion, KernelVersion<entryPointVersion>>,
+  parameters: KernelAccountClientConfig<entryPointVersion, KernelVersion<entryPointVersion>, owner>,
 ): Promise<{ client: KernelAccountClient<entryPointVersion>; args: DeployFactoryArgs }> {
   const { key = 'kernelAccountClient', name = 'Kernel Account Client', transport } = parameters
   const { account } = parameters
@@ -37,7 +47,8 @@ export async function createKernelAccountClient<
 
   const kernelAccount = await toEcdsaKernelSmartAccount<
     entryPointVersion,
-    KernelVersion<entryPointVersion>
+    KernelVersion<entryPointVersion>,
+    owner
   >({
     ...parameters,
     client,

--- a/src/transaction/smart-wallets/kernel/kernel-account-client-v2.service.ts
+++ b/src/transaction/smart-wallets/kernel/kernel-account-client-v2.service.ts
@@ -68,6 +68,7 @@ class KernelAccountClientV2ServiceBase<
     return {
       ...base,
       ownerAccount: this.signerService.getAccount(),
+      useMetaFactory: false,
       entryPoint: {
         address: entryPoint07Address,
         version: '0.7' as entryPointVersion,

--- a/src/transaction/smart-wallets/kernel/kernel-account-client-v2.service.ts
+++ b/src/transaction/smart-wallets/kernel/kernel-account-client-v2.service.ts
@@ -3,7 +3,16 @@ import { ViemMultichainClientService } from '../../viem_multichain_client.servic
 import { entryPoint07Address } from 'viem/account-abstraction'
 import { EcoConfigService } from '@/eco-configs/eco-config.service'
 import { SignerService } from '@/sign/signer.service'
-import { Chain, Hex, zeroAddress } from 'viem'
+import {
+  Account,
+  Chain,
+  Hex,
+  LocalAccount,
+  OneOf,
+  Transport,
+  WalletClient,
+  zeroAddress,
+} from 'viem'
 import { KernelVersion } from 'permissionless/accounts'
 import { entryPointV_0_7 } from './create.kernel.account'
 import {
@@ -11,13 +20,17 @@ import {
   KernelAccountClientV2,
   KernelAccountClientV2Config,
 } from '@/transaction/smart-wallets/kernel/create-kernel-client-v2.account'
+import { EthereumProvider } from 'permissionless/utils/toOwner'
 
 class KernelAccountClientV2ServiceBase<
   entryPointVersion extends '0.6' | '0.7',
   kernelVersion extends KernelVersion<entryPointVersion>,
+  owner extends OneOf<
+    EthereumProvider | WalletClient<Transport, Chain | undefined, Account> | LocalAccount
+  > = LocalAccount,
 > extends ViemMultichainClientService<
   KernelAccountClientV2<entryPointVersion>,
-  KernelAccountClientV2Config<entryPointVersion, kernelVersion>
+  KernelAccountClientV2Config<entryPointVersion, kernelVersion, owner>
 > {
   private logger = new Logger(KernelAccountClientV2ServiceBase.name)
 
@@ -43,14 +56,14 @@ class KernelAccountClientV2ServiceBase<
   }
 
   protected override async createInstanceClient(
-    configs: KernelAccountClientV2Config<entryPointVersion, kernelVersion>,
+    configs: KernelAccountClientV2Config<entryPointVersion, kernelVersion, owner>,
   ): Promise<KernelAccountClientV2<entryPointVersion>> {
     return createKernelAccountClientV2(configs)
   }
 
   protected override async buildChainConfig(
     chain: Chain,
-  ): Promise<KernelAccountClientV2Config<entryPointVersion, kernelVersion>> {
+  ): Promise<KernelAccountClientV2Config<entryPointVersion, kernelVersion, owner>> {
     const base = await super.buildChainConfig(chain)
     return {
       ...base,
@@ -59,7 +72,7 @@ class KernelAccountClientV2ServiceBase<
         address: entryPoint07Address,
         version: '0.7' as entryPointVersion,
       },
-      owners: [this.signerService.getAccount()],
+      owners: [this.signerService.getAccount() as owner],
       index: 0n, // optional
     }
   }

--- a/src/transaction/smart-wallets/kernel/kernel-account-client.service.ts
+++ b/src/transaction/smart-wallets/kernel/kernel-account-client.service.ts
@@ -65,6 +65,7 @@ export class KernelAccountClientServiceBase<
     return {
       ...base,
       account: this.signerService.getAccount(),
+      useMetaFactory: false,
       entryPoint: {
         address: entryPoint07Address,
         version: '0.7' as entryPointVersion,

--- a/src/transaction/smart-wallets/kernel/kernel-account.config.ts
+++ b/src/transaction/smart-wallets/kernel/kernel-account.config.ts
@@ -1,12 +1,26 @@
 import { KernelVersion, ToEcdsaKernelSmartAccountParameters } from 'permissionless/accounts'
-import { Prettify, WalletClientConfig } from 'viem'
+import {
+  Account,
+  Chain,
+  LocalAccount,
+  OneOf,
+  Prettify,
+  Transport,
+  WalletClient,
+  WalletClientConfig,
+} from 'viem'
 import { SmartWalletActions } from '../smart-wallet.types'
 import { DeployFactoryArgs } from './kernel-account.client'
+import { EthereumProvider } from 'permissionless/utils/toOwner'
 
 export type KernelAccountClientConfig<
   entryPointVersion extends '0.6' | '0.7',
   kernelVersion extends KernelVersion<entryPointVersion>,
-> = WalletClientConfig & ToEcdsaKernelSmartAccountParameters<entryPointVersion, kernelVersion>
+  owner extends OneOf<
+    EthereumProvider | WalletClient<Transport, Chain | undefined, Account> | LocalAccount
+  >,
+> = WalletClientConfig &
+  ToEcdsaKernelSmartAccountParameters<entryPointVersion, kernelVersion, owner>
 
 export type KernelWalletActions = Prettify<
   SmartWalletActions & {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6178,10 +6178,10 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-permissionless@^0.2.11:
-  version "0.2.21"
-  resolved "https://registry.yarnpkg.com/permissionless/-/permissionless-0.2.21.tgz#40746cf43f7e4d8cac399ae869a2e60442ec9a8e"
-  integrity sha512-hNrRR/I5InbqkKgRBLhXQY5R0j9biqp688ECBxsW5AO99jOv9HPjz82EdRT87OG4XkCjO4AY20hi4ZPoc+XjRg==
+permissionless@^0.2.33:
+  version "0.2.33"
+  resolved "https://registry.yarnpkg.com/permissionless/-/permissionless-0.2.33.tgz#bcc1a43c43bf260398c7b3e119f26d299490f022"
+  integrity sha512-8EfaTe7athm6+xFnPWClbNtRtDdslhYOY2EBxBEAgLgY7rz1OVXKSIr02o416ulaP2Zr9dHB28Br8HU9VgV1PA==
 
 picocolors@^1.0.0, picocolors@^1.1.0:
   version "1.1.1"
@@ -6781,7 +6781,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6813,7 +6822,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7445,7 +7461,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -7458,6 +7474,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Summary
The Meta Factory is like a proxy factory for staking ETH on the ERC-4337 EntryPoints, avoiding the need to stake ETH for every new factory. This Meta Factory has an owner who must whitelist wallet factories before wallets can be deployed using such factories. This is an issue on new chains where the ZeroDev team has to whitelist the factories to deploy Kernel wallets using the Meta factory.

We can deploy the Kernel Factory permissionlessly on any chain and create wallets by calling the Kernel Factory contract without using the Meta Factory. 

This PR upgrades the permissionless library and sets the `useMetaFactory` option to `false` which wasn't available in the previous version we were using.



