### PR TITLE
Liquidity Manager - Swap WETH to stable coint

### DIFF
--- a/src/eco-configs/eco-config.service.ts
+++ b/src/eco-configs/eco-config.service.ts
@@ -248,6 +248,10 @@ export class EcoConfigService {
     return this.get('rpcUrls')
   }
 
+  getWETH(): EcoConfigType['WETH'] {
+    return this.get('WETH')
+  }
+
   getChainRPCs() {
     const entries = ChainsSupported.map((chain) => [chain.id, this.getRpcUrl(chain).url])
     return Object.fromEntries(entries) as Record<number, string>

--- a/src/eco-configs/eco-config.types.ts
+++ b/src/eco-configs/eco-config.types.ts
@@ -65,6 +65,10 @@ export type EcoConfigType = {
     usePino: boolean
     pinoConfig: PinoParams
   }
+  WETH: {
+    threshold: string
+    addresses: Record<number, Hex>
+  }
   liquidityManager: LiquidityManagerConfig
   indexer: IndexerConfig
   withdraws: WithdrawsConfig

--- a/src/eco-configs/tests/eco-config.service.spec.ts
+++ b/src/eco-configs/tests/eco-config.service.spec.ts
@@ -197,4 +197,20 @@ describe('Eco Config Helper Tests', () => {
       expect(mockgetChainConfig).toHaveBeenCalledWith(mockSolver.chainID)
     })
   })
+
+  describe('on getWETH', () => {
+    it('should return the WETH configuration', () => {
+      const mockWETH = {
+        threshold: '0.1',
+        addresses: {
+          1: '0x1234567890123456789012345678901234567890',
+          10: '0x0987654321098765432109876543210987654321'
+        }
+      }
+      ecoConfigService.get = jest.fn().mockReturnValue(mockWETH)
+      const result = ecoConfigService.getWETH()
+      expect(result).toEqual(mockWETH)
+      expect(ecoConfigService.get).toHaveBeenCalledWith('WETH')
+    })
+  })
 })

--- a/src/liquidity-manager/jobs/check-balances-cron.job.ts
+++ b/src/liquidity-manager/jobs/check-balances-cron.job.ts
@@ -114,7 +114,7 @@ export class CheckBalancesCronJobManager extends LiquidityManagerJobManager {
       return
     }
 
-    const rebalances: RebalanceRequest[] = []
+    const tokenRebalances: RebalanceRequest[] = []
 
     for (const deficitToken of deficit.items) {
       const rebalancingQuotes = await processor.liquidityManagerService.getOptimizedRebalancing(
@@ -142,8 +142,12 @@ export class CheckBalancesCronJobManager extends LiquidityManagerJobManager {
       // Store rebalance request on DB
       await processor.liquidityManagerService.storeRebalancing(walletAddress, rebalanceRequest)
 
-      rebalances.push(rebalanceRequest)
+      tokenRebalances.push(rebalanceRequest)
     }
+
+    const wethRebalances = await processor.liquidityManagerService.getWETHRebalances(walletAddress)
+
+    const rebalances = [...wethRebalances, ...tokenRebalances]
 
     if (!rebalances.length) {
       processor.logger.warn(

--- a/src/liquidity-manager/tests/check-balances-cron.job.spec.ts
+++ b/src/liquidity-manager/tests/check-balances-cron.job.spec.ts
@@ -1,0 +1,227 @@
+import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import { Test, TestingModule } from '@nestjs/testing'
+import { zeroAddress } from 'viem'
+import { EcoConfigService } from '@/eco-configs/eco-config.service'
+import { BalanceService } from '@/balance/balance.service'
+import { LiquidityManagerService } from '@/liquidity-manager/services/liquidity-manager.service'
+import { CheckBalancesCronJobManager } from '@/liquidity-manager/jobs/check-balances-cron.job'
+import { KernelAccountClientService } from '@/transaction/smart-wallets/kernel/kernel-account-client.service'
+import { CrowdLiquidityService } from '@/intent/crowd-liquidity.service'
+import { EcoLogMessage } from '@/common/logging/eco-log-message'
+
+describe('CheckBalancesCronJobManager', () => {
+  let service: LiquidityManagerService
+  let balanceService: DeepMocked<BalanceService>
+  let ecoConfigService: DeepMocked<EcoConfigService>
+  let kernelAccountClientService: DeepMocked<KernelAccountClientService>
+  let crowdLiquidityService: DeepMocked<CrowdLiquidityService>
+  let checkBalancesCronJobManager: CheckBalancesCronJobManager
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LiquidityManagerService,
+        { provide: BalanceService, useValue: createMock<BalanceService>() },
+        { provide: EcoConfigService, useValue: createMock<EcoConfigService>() },
+        { provide: KernelAccountClientService, useValue: createMock<KernelAccountClientService>() },
+        { provide: CrowdLiquidityService, useValue: createMock<CrowdLiquidityService>() },
+      ],
+    }).compile()
+
+    service = module.get<LiquidityManagerService>(LiquidityManagerService)
+    balanceService = module.get(BalanceService)
+    ecoConfigService = module.get(EcoConfigService)
+    kernelAccountClientService = module.get(KernelAccountClientService)
+    crowdLiquidityService = module.get(CrowdLiquidityService)
+
+    // Setup mocks
+    crowdLiquidityService.getPoolAddress = jest.fn().mockResolvedValue(zeroAddress)
+    kernelAccountClientService.getClient = jest
+      .fn()
+      .mockResolvedValue({ kernelAccount: { address: zeroAddress } })
+
+    // Create job manager
+    checkBalancesCronJobManager = new CheckBalancesCronJobManager('test')
+  })
+
+  describe('process', () => {
+    it('should combine token rebalances and WETH rebalances', async () => {
+      // Mock processor object
+      const mockProcessor = {
+        liquidityManagerService: service,
+        logger: {
+          info: jest.fn(),
+          warn: jest.fn(),
+          error: jest.fn(),
+        },
+      }
+
+      // Mock token data
+      const mockDeficitAnalysis = {
+        items: [
+          { 
+            config: { address: '0xToken1' },
+            analysis: { 
+              diff: 100,
+              balance: { current: 50n },
+              targetSlippage: { min: 150n }
+            }
+          }
+        ]
+      }
+
+      // Mock rebalance request for tokens
+      const mockTokenRebalance = {
+        token: { address: '0xToken1' },
+        quotes: [{ amountIn: 100n, amountOut: 95n }]
+      }
+
+      // Mock WETH rebalance
+      const mockWETHRebalance = {
+        token: { address: '0xWETH' },
+        quotes: [{ amountIn: 200n, amountOut: 195n }]
+      }
+
+      // Setup mocks
+      jest.spyOn(service, 'analyzeTokens').mockResolvedValue({
+        ...mockDeficitAnalysis,
+        deficit: mockDeficitAnalysis,
+        surplus: { items: [] }
+      } as any)
+
+      jest.spyOn(service, 'getOptimizedRebalancing').mockResolvedValue([mockTokenRebalance] as any)
+      jest.spyOn(service, 'storeRebalancing').mockResolvedValue(undefined)
+      jest.spyOn(service, 'getWETHRebalances').mockResolvedValue([mockWETHRebalance] as any)
+      
+      // Call process method
+      await checkBalancesCronJobManager.process(mockProcessor as any)
+      
+      // Verify WETH rebalances were fetched
+      expect(service.getWETHRebalances).toHaveBeenCalledWith(zeroAddress)
+      
+      // Verify rebalance job was added with combined rebalances
+      const mockJobInfo = expect.objectContaining({
+        name: expect.stringContaining('rebalance'),
+        data: {
+          rebalance: expect.objectContaining({
+            walletAddress: zeroAddress,
+            rebalances: [mockWETHRebalance, mockTokenRebalance]
+          })
+        }
+      })
+      
+      // Should have logged about adding the job
+      expect(mockProcessor.logger.info).toHaveBeenCalledWith(
+        expect.any(EcoLogMessage),
+        expect.objectContaining({ 
+          jobInfo: mockJobInfo
+        })
+      )
+    })
+
+    it('should not add job when no rebalances are found', async () => {
+      // Mock processor object
+      const mockProcessor = {
+        liquidityManagerService: service,
+        logger: {
+          info: jest.fn(),
+          warn: jest.fn(),
+          error: jest.fn(),
+        },
+      }
+
+      // Setup mocks to return empty results
+      jest.spyOn(service, 'analyzeTokens').mockResolvedValue({
+        deficit: { items: [] },
+        surplus: { items: [] },
+        items: []
+      } as any)
+      
+      jest.spyOn(service, 'getWETHRebalances').mockResolvedValue([])
+      
+      // Call process method
+      await checkBalancesCronJobManager.process(mockProcessor as any)
+      
+      // Verify WETH rebalances were fetched
+      expect(service.getWETHRebalances).toHaveBeenCalledWith(zeroAddress)
+      
+      // Should have logged a warning about no rebalances
+      expect(mockProcessor.logger.warn).toHaveBeenCalledWith(
+        expect.any(EcoLogMessage),
+        expect.objectContaining({ 
+          message: expect.stringContaining('No rebalance')
+        })
+      )
+    })
+
+    it('should handle token rebalances even without WETH rebalances', async () => {
+      // Mock processor object
+      const mockProcessor = {
+        liquidityManagerService: service,
+        logger: {
+          info: jest.fn(),
+          warn: jest.fn(),
+          error: jest.fn(),
+        },
+      }
+
+      // Mock token data
+      const mockDeficitAnalysis = {
+        items: [
+          { 
+            config: { address: '0xToken1' },
+            analysis: { 
+              diff: 100,
+              balance: { current: 50n },
+              targetSlippage: { min: 150n }
+            }
+          }
+        ]
+      }
+
+      // Mock rebalance request for tokens
+      const mockTokenRebalance = {
+        token: { address: '0xToken1' },
+        quotes: [{ amountIn: 100n, amountOut: 95n }]
+      }
+
+      // Setup mocks
+      jest.spyOn(service, 'analyzeTokens').mockResolvedValue({
+        ...mockDeficitAnalysis,
+        deficit: mockDeficitAnalysis,
+        surplus: { items: [] }
+      } as any)
+
+      jest.spyOn(service, 'getOptimizedRebalancing').mockResolvedValue([mockTokenRebalance] as any)
+      jest.spyOn(service, 'storeRebalancing').mockResolvedValue(undefined)
+      
+      // Return empty WETH rebalances
+      jest.spyOn(service, 'getWETHRebalances').mockResolvedValue([])
+      
+      // Call process method
+      await checkBalancesCronJobManager.process(mockProcessor as any)
+      
+      // Verify getWETHRebalances was called
+      expect(service.getWETHRebalances).toHaveBeenCalledWith(zeroAddress)
+      
+      // Verify rebalance job was added with token rebalances only
+      const mockJobInfo = expect.objectContaining({
+        name: expect.stringContaining('rebalance'),
+        data: {
+          rebalance: expect.objectContaining({
+            walletAddress: zeroAddress,
+            rebalances: [mockTokenRebalance]
+          })
+        }
+      })
+      
+      // Should have logged about adding the job
+      expect(mockProcessor.logger.info).toHaveBeenCalledWith(
+        expect.any(EcoLogMessage),
+        expect.objectContaining({ 
+          jobInfo: mockJobInfo
+        })
+      )
+    })
+  })
+})

--- a/src/liquidity-manager/tests/liquidity-manager.service.spec.ts
+++ b/src/liquidity-manager/tests/liquidity-manager.service.spec.ts
@@ -272,4 +272,198 @@ describe('LiquidityManagerService', () => {
       expect(liquidityProviderService.execute).toHaveBeenCalledTimes(2)
     })
   })
+
+  describe('getWETHRebalances', () => {
+    it('should return empty array when wallet address is not kernel address', async () => {
+      const walletAddress = '0xUserWallet'
+      
+      // Mock getClient to return a different address than the walletAddress
+      kernelAccountClientService.getClient = jest.fn().mockResolvedValue({
+        kernelAccount: { address: '0xDifferentAddress' }
+      })
+
+      const result = await liquidityManagerService.getWETHRebalances(walletAddress)
+      
+      expect(result).toEqual([])
+      expect(kernelAccountClientService.getClient).toHaveBeenCalledWith(10) // OP chain
+    })
+
+    it('should call getWETHRebalance for each chain and return valid results', async () => {
+      const kernelAddress = '0xKernelAddress'
+      
+      // Mock getClient to return the same address as walletAddress
+      kernelAccountClientService.getClient = jest.fn().mockResolvedValue({
+        kernelAccount: { address: kernelAddress }
+      })
+
+      // Setup tokensPerWallet for multiple chains
+      liquidityManagerService['tokensPerWallet'] = {
+        [kernelAddress]: [
+          { chainId: 1, address: '0xToken1' },
+          { chainId: 10, address: '0xToken2' },
+        ]
+      }
+
+      // Mock getWETHRebalance to return rebalance requests
+      const rebalanceRequest1 = { token: { chainId: 1 }, quotes: [] }
+      const rebalanceRequest2 = { token: { chainId: 10 }, quotes: [] }
+      
+      // First call returns a rebalance, second returns undefined (no need to rebalance)
+      jest.spyOn(liquidityManagerService as any, 'getWETHRebalance')
+        .mockImplementation((address, chainId) => {
+          if (chainId === 1) return Promise.resolve(rebalanceRequest1)
+          if (chainId === 10) return Promise.resolve(rebalanceRequest2)
+          return Promise.resolve(undefined)
+        })
+
+      const result = await liquidityManagerService.getWETHRebalances(kernelAddress)
+      
+      expect(result).toEqual([rebalanceRequest1, rebalanceRequest2])
+      expect(liquidityManagerService['getWETHRebalance']).toHaveBeenCalledTimes(2)
+      expect(liquidityManagerService['getWETHRebalance']).toHaveBeenCalledWith(
+        kernelAddress, 1, expect.anything()
+      )
+      expect(liquidityManagerService['getWETHRebalance']).toHaveBeenCalledWith(
+        kernelAddress, 10, expect.anything()
+      )
+    })
+
+    it('should filter out undefined results from getWETHRebalance', async () => {
+      const kernelAddress = '0xKernelAddress'
+      
+      // Mock getClient to return the same address as walletAddress
+      kernelAccountClientService.getClient = jest.fn().mockResolvedValue({
+        kernelAccount: { address: kernelAddress }
+      })
+
+      // Setup tokensPerWallet for multiple chains
+      liquidityManagerService['tokensPerWallet'] = {
+        [kernelAddress]: [
+          { chainId: 1, address: '0xToken1' },
+          { chainId: 10, address: '0xToken2' },
+        ]
+      }
+
+      // Mock getWETHRebalance to return one rebalance request and one undefined
+      const rebalanceRequest = { token: { chainId: 1 }, quotes: [] }
+      
+      jest.spyOn(liquidityManagerService as any, 'getWETHRebalance')
+        .mockImplementation((address, chainId) => {
+          if (chainId === 1) return Promise.resolve(rebalanceRequest)
+          return Promise.resolve(undefined)
+        })
+
+      const result = await liquidityManagerService.getWETHRebalances(kernelAddress)
+      
+      expect(result).toEqual([rebalanceRequest])
+      expect(result.length).toBe(1)
+      expect(liquidityManagerService['getWETHRebalance']).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('getWETHRebalance', () => {
+    it('should return undefined when WETH balance is below threshold', async () => {
+      const walletAddress = '0xWalletAddress'
+      const chainId = 1
+      const token = { chainId: 1, address: '0xToken1' }
+      
+      // Mock client
+      const mockClient = {
+        readContract: jest.fn().mockResolvedValue(10n) // Low balance
+      }
+      kernelAccountClientService.getClient = jest.fn().mockResolvedValue(mockClient)
+      
+      // Mock config
+      const mockWETHConfig = {
+        addresses: { 1: '0xWETHAddress' },
+        threshold: '100' // Higher than current balance
+      }
+      ecoConfigService.getWETH = jest.fn().mockReturnValue(mockWETHConfig)
+      
+      const result = await (liquidityManagerService as any).getWETHRebalance(
+        walletAddress, chainId, token
+      )
+      
+      expect(result).toBeUndefined()
+      expect(mockClient.readContract).toHaveBeenCalledWith({
+        abi: expect.anything(),
+        functionName: 'balanceOf',
+        address: '0xWETHAddress',
+        args: [walletAddress]
+      })
+    })
+    
+    it('should return rebalance request when WETH balance exceeds threshold', async () => {
+      const walletAddress = '0xWalletAddress'
+      const chainId = 1
+      const token = { 
+        chainId: 1, 
+        address: '0xToken1',
+        type: 'erc20',
+        targetBalance: 100, 
+        minBalance: 50
+      }
+      
+      // Mock client with high WETH balance
+      const wethBalance = 200n
+      const mockClient = {
+        readContract: jest.fn().mockResolvedValue(wethBalance),
+        kernelAccount: { address: walletAddress }
+      }
+      kernelAccountClientService.getClient = jest.fn().mockResolvedValue(mockClient)
+      
+      // Mock WETH config with lower threshold
+      const wethAddress = '0xWETHAddress'
+      const mockWETHConfig = {
+        addresses: { 1: wethAddress },
+        threshold: '100' // Lower than current balance
+      }
+      ecoConfigService.getWETH = jest.fn().mockReturnValue(mockWETHConfig)
+      
+      // Mock token data response
+      const mockTokenOut = { 
+        config: { address: '0xToken1', chainId: 1 },
+        balance: { balance: 50n }
+      }
+      balanceService.getAllTokenDataForAddress = jest.fn().mockResolvedValue([mockTokenOut])
+      
+      // Mock quote response
+      const mockQuotes = [{ amountIn: 100n, amountOut: 95n }]
+      liquidityProviderService.getQuote = jest.fn().mockResolvedValue(mockQuotes)
+      
+      const result = await (liquidityManagerService as any).getWETHRebalance(
+        walletAddress, chainId, token
+      )
+      
+      // Verify the result structure
+      expect(result).toBeDefined()
+      expect(result.token).toEqual({
+        chainId,
+        config: { 
+          address: wethAddress, 
+          chainId, 
+          type: 'erc20', 
+          targetBalance: 0, 
+          minBalance: 0 
+        },
+        balance: { 
+          balance: wethBalance, 
+          address: wethAddress, 
+          decimals: 18 
+        }
+      })
+      expect(result.quotes).toEqual(mockQuotes)
+      
+      // Verify liquidity provider was called correctly
+      expect(liquidityProviderService.getQuote).toHaveBeenCalledWith(
+        walletAddress,
+        expect.objectContaining({ 
+          chainId,
+          config: { address: wethAddress } 
+        }),
+        mockTokenOut,
+        expect.any(Number)
+      )
+    })
+  })
 })


### PR DESCRIPTION
This pull request introduces functionality for handling WETH (Wrapped Ether) rebalances in the liquidity management system. The changes include updates to configuration, new methods for calculating WETH rebalances, and extensive testing to ensure correctness. Below are the key updates:

### WETH Configuration and Access
* Added a new `WETH` property to the `EcoConfigType` type, which includes a `threshold` and `addresses` for different chains (`src/eco-configs/eco-config.types.ts`).
* Implemented a `getWETH` method in the `EcoConfigService` to retrieve WETH configuration (`src/eco-configs/eco-config.service.ts`).

### Liquidity Management Enhancements
* Introduced a `getWETHRebalances` method in the `LiquidityManagerService` to calculate WETH rebalances across chains. This method uses the WETH configuration and checks balances against the threshold (`src/liquidity-manager/services/liquidity-manager.service.ts`).
* Added a private `getWETHRebalance` method to handle individual WETH rebalance calculations, including balance checks and quote generation (`src/liquidity-manager/services/liquidity-manager.service.ts`).
* Updated the `CheckBalancesCronJobManager` to combine WETH rebalances with token rebalances for processing (`src/liquidity-manager/jobs/check-balances-cron.job.ts`).

### Testing
* Added unit tests for the `getWETH` method in `EcoConfigService` to verify WETH configuration retrieval (`src/eco-configs/tests/eco-config.service.spec.ts`).
* Created tests for the `getWETHRebalances` and `getWETHRebalance` methods in `LiquidityManagerService`, covering scenarios like balance thresholds and multi-chain handling (`src/liquidity-manager/tests/liquidity-manager.service.spec.ts`).
* Developed integration tests for the `CheckBalancesCronJobManager` to ensure proper handling of combined WETH and token rebalances (`src/liquidity-manager/tests/check-balances-cron.job.spec.ts`).

### Codebase Cleanup
* Renamed the `rebalances` variable to `tokenRebalances` in `CheckBalancesCronJobManager` for clarity (`src/liquidity-manager/jobs/check-balances-cron.job.ts`).
* Added imports for utility functions and types used in the new WETH rebalance logic (`src/liquidity-manager/services/liquidity-manager.service.ts`).