### PR TITLE
Maximum slippage

### DIFF
--- a/config/default.ts
+++ b/config/default.ts
@@ -103,6 +103,7 @@ export default {
   liquidityManager: {
     intervalDuration: 300000,
     targetSlippage: 0.02,
+    maxQuoteSlippage: 0.005, // 0.5% maximum slippage allowed for quotes
     thresholds: {
       surplus: 0.1,
       deficit: 0.2,

--- a/config/default.ts
+++ b/config/default.ts
@@ -103,7 +103,7 @@ export default {
   liquidityManager: {
     intervalDuration: 300000,
     targetSlippage: 0.02,
-    maxQuoteSlippage: 0.005, // 0.5% maximum slippage allowed for quotes
+    maxQuoteSlippage: 0.001, // 0.1% maximum slippage allowed for quotes
     thresholds: {
       surplus: 0.1,
       deficit: 0.2,

--- a/config/default.ts
+++ b/config/default.ts
@@ -103,7 +103,7 @@ export default {
   liquidityManager: {
     intervalDuration: 300000,
     targetSlippage: 0.02,
-    maxQuoteSlippage: 0.001, // 0.1% maximum slippage allowed for quotes
+    maxQuoteSlippage: 0.0005, // 0.05% maximum slippage allowed for quotes
     thresholds: {
       surplus: 0.1,
       deficit: 0.2,

--- a/config/default.ts
+++ b/config/default.ts
@@ -103,7 +103,6 @@ export default {
   liquidityManager: {
     intervalDuration: 300000,
     targetSlippage: 0.02,
-    maxQuoteSlippage: 0.0005, // 0.05% maximum slippage allowed for quotes
     thresholds: {
       surplus: 0.1,
       deficit: 0.2,

--- a/src/eco-configs/eco-config.types.ts
+++ b/src/eco-configs/eco-config.types.ts
@@ -312,6 +312,8 @@ export class IntentSource {
 export interface LiquidityManagerConfig {
   // The maximum slippage around target balance for a token
   targetSlippage: number
+  // Maximum allowed slippage for quotes (e.g., 0.05 for 5%)
+  maxQuoteSlippage: number
   intervalDuration: number
   thresholds: {
     surplus: number // Percentage above target balance

--- a/src/eco-configs/eco-config.types.ts
+++ b/src/eco-configs/eco-config.types.ts
@@ -310,6 +310,7 @@ export class IntentSource {
 }
 
 export interface LiquidityManagerConfig {
+  enabled?: boolean
   // The maximum slippage around target balance for a token
   targetSlippage: number
   // Maximum allowed slippage for quotes (e.g., 0.05 for 5%)

--- a/src/liquidity-manager/services/liquidity-manager.service.ts
+++ b/src/liquidity-manager/services/liquidity-manager.service.ts
@@ -69,6 +69,12 @@ export class LiquidityManagerService implements OnApplicationBootstrap {
     // Get wallet addresses we'll be monitoring
     this.config = this.ecoConfigService.getLiquidityManager()
 
+    if (this.config.enabled !== false) {
+      await this.initializeRebalances()
+    }
+  }
+
+  async initializeRebalances() {
     // Use OP as the default chain assuming the Kernel wallet is the same across all chains
     const opChainId = 10
     const client = await this.kernelAccountClientService.getClient(opChainId)

--- a/src/liquidity-manager/services/liquidity-provider.service.spec.ts
+++ b/src/liquidity-manager/services/liquidity-provider.service.spec.ts
@@ -5,6 +5,7 @@ import { LiFiProviderService } from '@/liquidity-manager/services/liquidity-prov
 import { CCTPProviderService } from '@/liquidity-manager/services/liquidity-providers/CCTP/cctp-provider.service'
 import { CrowdLiquidityService } from '@/intent/crowd-liquidity.service'
 import { WarpRouteProviderService } from '@/liquidity-manager/services/liquidity-providers/Hyperlane/warp-route-provider.service'
+import { EcoConfigService } from '@/eco-configs/eco-config.service'
 
 const walletAddr = '0xWalletAddress'
 
@@ -13,6 +14,7 @@ describe('LiquidityProviderService', () => {
   let liFiProviderService: LiFiProviderService
   let cctpProviderService: CCTPProviderService
   let warpRouteProviderService: WarpRouteProviderService
+  let ecoConfigService: EcoConfigService
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -22,6 +24,12 @@ describe('LiquidityProviderService', () => {
         { provide: CCTPProviderService, useValue: createMock<CCTPProviderService>() },
         { provide: CrowdLiquidityService, useValue: createMock<CrowdLiquidityService>() },
         { provide: WarpRouteProviderService, useValue: createMock<WarpRouteProviderService>() },
+        {
+          provide: EcoConfigService,
+          useValue: {
+            getLiquidityManager: jest.fn().mockReturnValue({ maxQuoteSlippage: 0.005 }),
+          },
+        },
       ],
     }).compile()
 
@@ -29,6 +37,7 @@ describe('LiquidityProviderService', () => {
     liFiProviderService = module.get<LiFiProviderService>(LiFiProviderService)
     cctpProviderService = module.get<CCTPProviderService>(CCTPProviderService)
     warpRouteProviderService = module.get<WarpRouteProviderService>(WarpRouteProviderService)
+    ecoConfigService = module.get<EcoConfigService>(EcoConfigService)
   })
 
   describe('getQuote', () => {
@@ -42,6 +51,8 @@ describe('LiquidityProviderService', () => {
           amountOut: 200n,
           tokenIn: mockTokenIn,
           tokenOut: mockTokenOut,
+          slippage: 0.004, // 0.4% slippage - within limit
+          strategy: 'LiFi',
         },
       ]
 
@@ -63,14 +74,85 @@ describe('LiquidityProviderService', () => {
       )
       expect(result).toEqual(mockQuote)
     })
+
+    it('should filter out quotes exceeding maximum slippage', async () => {
+      const mockTokenIn = { chainId: 1, config: { address: '0xTokenIn' } }
+      const mockTokenOut = { chainId: 2, config: { address: '0xTokenOut' } }
+      const mockSwapAmount = 100
+      const mockQuotes = [
+        {
+          amountIn: 100n,
+          amountOut: 200n,
+          tokenIn: mockTokenIn,
+          tokenOut: mockTokenOut,
+          slippage: 0.006, // 0.6% slippage - exceeds 0.5% limit
+          strategy: 'LiFi',
+        },
+        {
+          amountIn: 100n,
+          amountOut: 195n,
+          tokenIn: mockTokenIn,
+          tokenOut: mockTokenOut,
+          slippage: 0.003, // 0.3% slippage - within limit
+          strategy: 'LiFi',
+        },
+      ]
+
+      jest.spyOn(liFiProviderService, 'getQuote').mockResolvedValue(mockQuotes as any)
+      jest.spyOn(warpRouteProviderService, 'getQuote').mockResolvedValue([])
+
+      const result = await liquidityProviderService.getQuote(
+        walletAddr,
+        mockTokenIn as any,
+        mockTokenOut as any,
+        mockSwapAmount,
+      )
+
+      expect(result).toHaveLength(1)
+      expect(result[0].slippage).toBe(0.003)
+    })
+
+    it('should throw error if all quotes exceed maximum slippage', async () => {
+      const mockTokenIn = { chainId: 1, config: { address: '0xTokenIn' } }
+      const mockTokenOut = { chainId: 2, config: { address: '0xTokenOut' } }
+      const mockSwapAmount = 100
+      const mockQuotes = [
+        {
+          amountIn: 100n,
+          amountOut: 200n,
+          tokenIn: mockTokenIn,
+          tokenOut: mockTokenOut,
+          slippage: 0.006, // 0.6% slippage - exceeds limit
+          strategy: 'LiFi',
+        },
+      ]
+
+      jest.spyOn(liFiProviderService, 'getQuote').mockResolvedValue(mockQuotes as any)
+      jest.spyOn(warpRouteProviderService, 'getQuote').mockResolvedValue([])
+
+      await expect(
+        liquidityProviderService.getQuote(
+          walletAddr,
+          mockTokenIn as any,
+          mockTokenOut as any,
+          mockSwapAmount,
+        ),
+      ).rejects.toThrow('Unable to get quote for route')
+    })
   })
 
   describe('fallback', () => {
     it('should call liFiProvider.fallback', async () => {
-      const mockTokenIn = { chainId: 1 }
-      const mockTokenOut = { chainId: 2 }
+      const mockTokenIn = { chainId: 1, config: { address: '0xTokenIn' } }
+      const mockTokenOut = { chainId: 2, config: { address: '0xTokenOut' } }
       const mockSwapAmount = 100
-      const mockQuote = { amountIn: 100n, amountOut: 200n }
+      const mockQuote = {
+        amountIn: 100n,
+        amountOut: 200n,
+        slippage: 0.003, // 0.3% slippage - within limit
+        tokenIn: mockTokenIn,
+        tokenOut: mockTokenOut,
+      }
 
       jest.spyOn(liFiProviderService, 'fallback').mockResolvedValue(mockQuote as any)
 
@@ -86,6 +168,25 @@ describe('LiquidityProviderService', () => {
         mockSwapAmount,
       )
       expect(result).toEqual(mockQuote)
+    })
+
+    it('should throw error if fallback quote exceeds maximum slippage', async () => {
+      const mockTokenIn = { chainId: 1, config: { address: '0xTokenIn' } }
+      const mockTokenOut = { chainId: 2, config: { address: '0xTokenOut' } }
+      const mockSwapAmount = 100
+      const mockQuote = {
+        amountIn: 100n,
+        amountOut: 200n,
+        slippage: 0.006, // 0.6% slippage - exceeds 0.5% limit
+        tokenIn: mockTokenIn,
+        tokenOut: mockTokenOut,
+      }
+
+      jest.spyOn(liFiProviderService, 'fallback').mockResolvedValue(mockQuote as any)
+
+      await expect(
+        liquidityProviderService.fallback(mockTokenIn as any, mockTokenOut as any, mockSwapAmount),
+      ).rejects.toThrow('Fallback quote slippage 0.006 exceeds maximum allowed 0.005')
     })
   })
 

--- a/src/liquidity-manager/services/liquidity-provider.service.ts
+++ b/src/liquidity-manager/services/liquidity-provider.service.ts
@@ -6,6 +6,7 @@ import { IRebalanceProvider } from '@/liquidity-manager/interfaces/IRebalancePro
 import { LiFiProviderService } from '@/liquidity-manager/services/liquidity-providers/LiFi/lifi-provider.service'
 import { CCTPProviderService } from '@/liquidity-manager/services/liquidity-providers/CCTP/cctp-provider.service'
 import { WarpRouteProviderService } from '@/liquidity-manager/services/liquidity-providers/Hyperlane/warp-route-provider.service'
+import { EcoConfigService } from '@/eco-configs/eco-config.service'
 
 @Injectable()
 export class LiquidityProviderService {
@@ -16,6 +17,7 @@ export class LiquidityProviderService {
     protected readonly cctpProviderService: CCTPProviderService,
     protected readonly crowdLiquidityService: CrowdLiquidityService,
     protected readonly warpRouteProviderService: WarpRouteProviderService,
+    protected readonly ecoConfigService: EcoConfigService,
   ) {}
 
   async getQuote(
@@ -25,13 +27,39 @@ export class LiquidityProviderService {
     swapAmount: number,
   ): Promise<RebalanceQuote[]> {
     const strategies = this.getWalletSupportedStrategies(walletAddress)
+    const maxQuoteSlippage = this.ecoConfigService.getLiquidityManager().maxQuoteSlippage
 
     // Iterate over strategies and return the first quote
     const quoteBatchRequests = strategies.map(async (strategy) => {
       try {
         const service = this.getStrategyService(strategy)
         const quotes = await service.getQuote(tokenIn, tokenOut, swapAmount)
-        return Array.isArray(quotes) ? quotes : [quotes]
+        const quotesArray = Array.isArray(quotes) ? quotes : [quotes]
+
+        // Filter out quotes that exceed maximum slippage
+        const validQuotes = quotesArray.filter((quote) => {
+          const exceedsSlippage = quote.slippage > maxQuoteSlippage
+          if (exceedsSlippage) {
+            this.logger.warn(
+              EcoLogMessage.fromDefault({
+                message: 'Quote rejected due to excessive slippage',
+                properties: {
+                  strategy,
+                  slippage: quote.slippage,
+                  maxQuoteSlippage,
+                  tokenIn: this.formatToken(tokenIn),
+                  tokenOut: this.formatToken(tokenOut),
+                  amountIn: quote.amountIn.toString(),
+                  amountOut: quote.amountOut.toString(),
+                },
+              }),
+            )
+            return false
+          }
+          return true
+        })
+
+        return validQuotes.length > 0 ? validQuotes : undefined
       } catch (error) {
         this.logger.error(
           EcoLogMessage.withError({
@@ -45,8 +73,11 @@ export class LiquidityProviderService {
 
     const quoteBatchResults = await Promise.all(quoteBatchRequests)
 
+    // Filter out undefined results
+    const validQuoteBatches = quoteBatchResults.filter((batch) => batch !== undefined)
+
     // Use the quote from the strategy returning the biggest amount out
-    const bestQuote = quoteBatchResults.reduce((bestBatch, quoteBatch) => {
+    const bestQuote = validQuoteBatches.reduce((bestBatch, quoteBatch) => {
       if (!bestBatch) return quoteBatch
       if (!quoteBatch) return bestBatch
 
@@ -54,7 +85,7 @@ export class LiquidityProviderService {
       const quote = quoteBatch[quoteBatch.length - 1]
 
       return (bestQuote?.amountOut ?? 0n) >= (quote?.amountOut ?? 0n) ? bestBatch : quoteBatch
-    }, quoteBatchResults[0])
+    }, validQuoteBatches[0])
 
     if (!bestQuote) {
       throw new Error('Unable to get quote for route')
@@ -102,7 +133,29 @@ export class LiquidityProviderService {
     tokenOut: TokenData,
     swapAmount: number,
   ): Promise<RebalanceQuote> {
-    return this.liFiProviderService.fallback(tokenIn, tokenOut, swapAmount)
+    const quote = await this.liFiProviderService.fallback(tokenIn, tokenOut, swapAmount)
+    const maxQuoteSlippage = this.ecoConfigService.getLiquidityManager().maxQuoteSlippage
+
+    if (quote.slippage > maxQuoteSlippage) {
+      this.logger.error(
+        EcoLogMessage.fromDefault({
+          message: 'Fallback quote rejected due to excessive slippage',
+          properties: {
+            slippage: quote.slippage,
+            maxQuoteSlippage,
+            tokenIn: this.formatToken(tokenIn),
+            tokenOut: this.formatToken(tokenOut),
+            amountIn: quote.amountIn.toString(),
+            amountOut: quote.amountOut.toString(),
+          },
+        }),
+      )
+      throw new Error(
+        `Fallback quote slippage ${quote.slippage} exceeds maximum allowed ${maxQuoteSlippage}`,
+      )
+    }
+
+    return quote
   }
 
   private getStrategyService(strategy: Strategy): IRebalanceProvider<Strategy> {

--- a/src/liquidity-manager/services/liquidity-providers/LiFi/lifi-provider.service.spec.ts
+++ b/src/liquidity-manager/services/liquidity-providers/LiFi/lifi-provider.service.spec.ts
@@ -85,8 +85,8 @@ describe('LiFiProviderService', () => {
       }
       const mockRoute = {
         fromAmount: '1000000000000000000',
-        toAmount: '2000000000000000000',
-        toAmountMin: '1900000000000000000',
+        toAmount: '1000000000000000000',
+        toAmountMin: '900000000000000000',
         steps: [],
       }
       jest.spyOn(LiFi, 'getRoutes').mockResolvedValue({ routes: [mockRoute] } as any)
@@ -95,7 +95,7 @@ describe('LiFiProviderService', () => {
 
       expect(result.amountIn).toEqual(BigInt(mockRoute.fromAmount))
       expect(result.amountOut).toEqual(BigInt(mockRoute.toAmount))
-      expect(result.slippage).toBeCloseTo(0.05)
+      expect(result.slippage).toBeCloseTo(0.1)
       expect(result.tokenIn).toEqual(mockTokenIn)
       expect(result.tokenOut).toEqual(mockTokenOut)
       expect(result.strategy).toEqual('LiFi')

--- a/src/liquidity-manager/services/liquidity-providers/LiFi/lifi-provider.service.ts
+++ b/src/liquidity-manager/services/liquidity-providers/LiFi/lifi-provider.service.ts
@@ -78,7 +78,8 @@ export class LiFiProviderService implements OnModuleInit, IRebalanceProvider<'Li
     const result = await getRoutes(routesRequest)
     const route = this.selectRoute(result.routes)
 
-    const slippage = 1 - parseFloat(route.toAmountMin) / parseFloat(route.toAmount)
+    // This assumes tokens are 1:1
+    const slippage = 1 - parseFloat(route.toAmountMin) / parseFloat(route.fromAmount)
 
     return {
       amountIn: BigInt(route.fromAmount),

--- a/src/liquidity-manager/services/liquidity-providers/LiFi/lifi-provider.service.ts
+++ b/src/liquidity-manager/services/liquidity-providers/LiFi/lifi-provider.service.ts
@@ -56,6 +56,8 @@ export class LiFiProviderService implements OnModuleInit, IRebalanceProvider<'Li
     tokenOut: TokenData,
     swapAmount: number,
   ): Promise<RebalanceQuote<'LiFi'>> {
+    const { maxQuoteSlippage } = this.ecoConfigService.getLiquidityManager()
+
     const routesRequest: RoutesRequest = {
       // Origin chain
       fromAddress: this.walletAddress,
@@ -67,6 +69,10 @@ export class LiFiProviderService implements OnModuleInit, IRebalanceProvider<'Li
       toAddress: this.walletAddress,
       toChainId: tokenOut.chainId,
       toTokenAddress: tokenOut.config.address,
+
+      options: {
+        slippage: maxQuoteSlippage,
+      },
     }
 
     const result = await getRoutes(routesRequest)

--- a/src/liquidity-manager/tests/liquidity-manager.service.spec.ts
+++ b/src/liquidity-manager/tests/liquidity-manager.service.spec.ts
@@ -66,6 +66,7 @@ describe('LiquidityManagerService', () => {
 
   const mockConfig = {
     targetSlippage: 0.02,
+    maxQuoteSlippage: 0.01,
     intervalDuration: 1000,
     thresholds: { surplus: 0.1, deficit: 0.2 },
     coreTokens: [


### PR DESCRIPTION
## Summary

  - Added maximum slippage validation to the liquidity manager to reject quotes that exceed configured limits
  - Quotes with slippage above the configured threshold (0.05%) are now automatically filtered out

##  Changes

  - Added maxQuoteSlippage configuration parameter to LiquidityManagerConfig interface
  - Implemented slippage validation in LiquidityProviderService.getQuote() and fallback() methods
  - Added logging for rejected quotes to track when quotes exceed slippage limits
  - Updated tests to cover slippage validation scenarios

##  Configuration

  The maximum allowed slippage is now configurable via liquidityManager.maxQuoteSlippage in the config files. Default is set to 0.005 (0.5%).