### PR TITLE
Only enable native if the flag is enabled and if the native token is ETH

### DIFF
--- a/config/default.ts
+++ b/config/default.ts
@@ -90,7 +90,7 @@ export default {
   gaslessIntentdAppIDs: ['token-pair-validation', 'matrix-test', 'test', 'sdk-demo'],
 
   intentConfigs: {
-    isNativeSupported: true,
+    isNativeETHSupported: true,
     defaultFee: {
       limit: {
         tokenBase6: 1000n * 10n ** 6n,

--- a/src/eco-configs/eco-config.types.ts
+++ b/src/eco-configs/eco-config.types.ts
@@ -149,7 +149,7 @@ export type IntentConfig = {
     hyperlane_duration_seconds: number
     metalayer_duration_seconds: number
   }
-  isNativeSupported: boolean
+  isNativeETHSupported: boolean
 }
 
 /**

--- a/src/intent/tests/utils.spec.ts
+++ b/src/intent/tests/utils.spec.ts
@@ -12,6 +12,7 @@ import {
   getFunctionCalls,
   getNativeCalls,
   getFunctionTargets,
+  isNativeETH,
 } from '@/intent/utils'
 import { Logger } from '@nestjs/common'
 
@@ -449,6 +450,98 @@ describe('utils tests', () => {
       const result = getFunctionTargets([])
 
       expect(result).toEqual([])
+    })
+  })
+
+  describe('on isNativeETH', () => {
+    beforeEach(() => {
+      mockExtractChain.mockClear()
+    })
+
+    it('should return true when both chains are ETH', () => {
+      const intent = {
+        route: { source: 1n, destination: 2n },
+      } as any
+
+      mockExtractChain.mockReturnValueOnce({ nativeCurrency: { symbol: 'ETH' } }) // source chain
+      mockExtractChain.mockReturnValueOnce({ nativeCurrency: { symbol: 'ETH' } }) // destination chain
+
+      expect(isNativeETH(intent)).toBe(true)
+    })
+
+    it('should return false when source chain is not found', () => {
+      const intent = {
+        route: { source: 1n, destination: 2n },
+      } as any
+
+      mockExtractChain.mockReturnValueOnce(null) // source chain not found
+      mockExtractChain.mockReturnValueOnce({ nativeCurrency: { symbol: 'ETH' } }) // destination chain
+
+      expect(isNativeETH(intent)).toBe(false)
+    })
+
+    it('should return false when destination chain is not found', () => {
+      const intent = {
+        route: { source: 1n, destination: 2n },
+      } as any
+
+      mockExtractChain.mockReturnValueOnce({ nativeCurrency: { symbol: 'ETH' } }) // source chain
+      mockExtractChain.mockReturnValueOnce(null) // destination chain not found
+
+      expect(isNativeETH(intent)).toBe(false)
+    })
+
+    it('should return false when source chain is not ETH', () => {
+      const intent = {
+        route: { source: 1n, destination: 2n },
+      } as any
+
+      mockExtractChain.mockReturnValueOnce({ nativeCurrency: { symbol: 'MATIC' } }) // source chain
+      mockExtractChain.mockReturnValueOnce({ nativeCurrency: { symbol: 'ETH' } }) // destination chain
+
+      expect(isNativeETH(intent)).toBe(false)
+    })
+
+    it('should return false when destination chain is not ETH', () => {
+      const intent = {
+        route: { source: 1n, destination: 2n },
+      } as any
+
+      mockExtractChain.mockReturnValueOnce({ nativeCurrency: { symbol: 'ETH' } }) // source chain
+      mockExtractChain.mockReturnValueOnce({ nativeCurrency: { symbol: 'MATIC' } }) // destination chain
+
+      expect(isNativeETH(intent)).toBe(false)
+    })
+
+    it('should return false when both chains are not ETH', () => {
+      const intent = {
+        route: { source: 1n, destination: 2n },
+      } as any
+
+      mockExtractChain.mockReturnValueOnce({ nativeCurrency: { symbol: 'MATIC' } }) // source chain
+      mockExtractChain.mockReturnValueOnce({ nativeCurrency: { symbol: 'MATIC' } }) // destination chain
+
+      expect(isNativeETH(intent)).toBe(false)
+    })
+
+    it('should call extractChain with correct parameters', () => {
+      const intent = {
+        route: { source: 1n, destination: 137n },
+      } as any
+
+      mockExtractChain.mockReturnValue({ nativeCurrency: { symbol: 'ETH' } })
+
+      isNativeETH(intent)
+
+      expect(mockExtractChain).toHaveBeenCalledTimes(2)
+      expect(mockExtractChain).toHaveBeenNthCalledWith(1, {
+        chains: expect.anything(),
+        id: 1,
+      })
+      expect(mockExtractChain).toHaveBeenNthCalledWith(2, {
+        chains: expect.anything(),
+        id: 137,
+      })
     })
   })
 })

--- a/src/intent/utils.ts
+++ b/src/intent/utils.ts
@@ -14,6 +14,7 @@ import { isEmptyData } from '../common/viem/utils'
 
 // The default number of decimals for native tokens that we enfores for now
 const DEFAULT_NATIVE_DECIMALS = 18
+const ETH_SYMBOL = 'ETH'
 
 /**
  * Decodes the function data for a target contract
@@ -148,4 +149,21 @@ export function getNativeCalls(calls: CallDataInterface[]) {
  */
 export function getFunctionTargets(calls: CallDataInterface[]) {
   return getFunctionCalls(calls).map((call) => call.target)
+}
+
+export function isNativeETH(intent: ValidationIntentInterface): boolean {
+  const sourceChain = extractChain({
+    chains: ChainsSupported,
+    id: Number(intent.route.source),
+  })
+  const dstChain = extractChain({
+    chains: ChainsSupported,
+    id: Number(intent.route.destination),
+  })
+  if (!sourceChain || !dstChain) {
+    return false
+  }
+  return (
+    sourceChain.nativeCurrency.symbol == ETH_SYMBOL && dstChain.nativeCurrency.symbol == ETH_SYMBOL
+  )
 }

--- a/src/intent/validation.sevice.ts
+++ b/src/intent/validation.sevice.ts
@@ -7,6 +7,7 @@ import {
   getFunctionCalls,
   getFunctionTargets,
   getTransactionTargetData,
+  isNativeETH,
   isNativeIntent,
 } from '@/intent/utils'
 import { TransactionTargetData } from '@/intent/utils-intent.service'
@@ -73,7 +74,7 @@ export type TxValidationFn = (tx: TransactionTargetData) => boolean
 
 @Injectable()
 export class ValidationService implements OnModuleInit {
-  private isNativeEnabled = false
+  private isNativeETHSupported = false
   private readonly logger = new Logger(ValidationService.name)
 
   constructor(
@@ -83,7 +84,7 @@ export class ValidationService implements OnModuleInit {
   ) {}
 
   onModuleInit() {
-    this.isNativeEnabled = this.ecoConfigService.getIntentConfigs().isNativeSupported
+    this.isNativeETHSupported = this.ecoConfigService.getIntentConfigs().isNativeETHSupported
   }
   /**
    * Executes all the validations we have on the model and solver
@@ -150,9 +151,9 @@ export class ValidationService implements OnModuleInit {
    * @returns
    */
   supportedNative(intent: ValidationIntentInterface): boolean {
-    if (this.isNativeEnabled) {
+    if (this.isNativeETHSupported) {
       if (isNativeIntent(intent)) {
-        return equivalentNativeGas(intent, this.logger)
+        return equivalentNativeGas(intent, this.logger) && isNativeETH(intent)
       }
       return true
     } else {


### PR DESCRIPTION
This pull request introduces a key update to the handling of native token support, transitioning from a general `isNativeSupported` flag to a more specific `isNativeETHSupported` flag. Additionally, it adds a new utility function, `isNativeETH`, to validate whether both source and destination chains use ETH as their native currency. Corresponding updates are made across configuration files, utility functions, and test cases to ensure consistency and proper functionality.

### Transition to `isNativeETHSupported`:

* **Configuration Update**: Renamed `isNativeSupported` to `isNativeETHSupported` in `intentConfigs` within `config/default.ts` and updated the `IntentConfig` type definition accordingly. [[1]](diffhunk://#diff-7fa39eae2d5e21a7dfc292f16e8c724031f87a9747ad0c7001e4db6d9607407bL93-R93) [[2]](diffhunk://#diff-31505ba579385f83b176b2bca49832ef2211b592014d5c8fe4f830f04d5f88abL152-R152)
* **Validation Service**: Updated `ValidationService` to use `isNativeETHSupported` instead of `isNativeEnabled`, including module initialization and native support checks. [[1]](diffhunk://#diff-339b10f6ea99262b3ca05a780e78ebb8f5753e8fe80ab8ee6858120c76d13898L76-R77) [[2]](diffhunk://#diff-339b10f6ea99262b3ca05a780e78ebb8f5753e8fe80ab8ee6858120c76d13898L86-R87) [[3]](diffhunk://#diff-339b10f6ea99262b3ca05a780e78ebb8f5753e8fe80ab8ee6858120c76d13898L153-R156)

### Addition of `isNativeETH` Utility:

* **Utility Function**: Added `isNativeETH` to `src/intent/utils.ts` to check if both source and destination chains use ETH as their native currency.
* **Test Coverage**: Comprehensive tests for `isNativeETH` added in `src/intent/tests/utils.spec.ts`, covering various scenarios such as missing chain data and mismatched native currencies.

### Updates to Test Cases:

* **ValidationService Tests**: Modified test cases in `validation.service.spec.ts` to incorporate `isNativeETHSupported` and validate the behavior of `isNativeETH` in native support checks. [[1]](diffhunk://#diff-19a6ff72bc03dee8b473da364272a8181f1cecd742ade4a75eaf256d555abd76L57-R66) [[2]](diffhunk://#diff-19a6ff72bc03dee8b473da364272a8181f1cecd742ade4a75eaf256d555abd76R165-R181) [[3]](diffhunk://#diff-19a6ff72bc03dee8b473da364272a8181f1cecd742ade4a75eaf256d555abd76L189-R226)

These changes enhance the specificity of native token handling, improve validation logic, and ensure robust testing for the new functionality.