### PR TITLE
LiFi - Swap slippage

### DIFF
--- a/src/eco-configs/eco-config.types.ts
+++ b/src/eco-configs/eco-config.types.ts
@@ -370,6 +370,7 @@ export interface LiquidityManagerConfig {
   targetSlippage: number
   // Maximum allowed slippage for quotes (e.g., 0.05 for 5%)
   maxQuoteSlippage: number
+  swapSlippage?: number
   intervalDuration: number
   thresholds: {
     surplus: number // Percentage above target balance

--- a/src/liquidity-manager/services/liquidity-providers/LiFi/lifi-provider.service.ts
+++ b/src/liquidity-manager/services/liquidity-providers/LiFi/lifi-provider.service.ts
@@ -59,8 +59,6 @@ export class LiFiProviderService implements OnModuleInit, IRebalanceProvider<'Li
     tokenOut: TokenData,
     swapAmount: number,
   ): Promise<RebalanceQuote<'LiFi'>> {
-    const { maxQuoteSlippage } = this.ecoConfigService.getLiquidityManager()
-
     const routesRequest: RoutesRequest = {
       // Origin chain
       fromAddress: this.walletAddress,
@@ -72,10 +70,6 @@ export class LiFiProviderService implements OnModuleInit, IRebalanceProvider<'Li
       toAddress: this.walletAddress,
       toChainId: tokenOut.chainId,
       toTokenAddress: tokenOut.config.address,
-
-      options: {
-        slippage: maxQuoteSlippage,
-      },
     }
 
     const result = await getRoutes(routesRequest)

--- a/src/liquidity-manager/services/liquidity-providers/LiFi/lifi-provider.service.ts
+++ b/src/liquidity-manager/services/liquidity-providers/LiFi/lifi-provider.service.ts
@@ -59,6 +59,8 @@ export class LiFiProviderService implements OnModuleInit, IRebalanceProvider<'Li
     tokenOut: TokenData,
     swapAmount: number,
   ): Promise<RebalanceQuote<'LiFi'>> {
+    const { swapSlippage } = this.ecoConfigService.getLiquidityManager()
+
     const routesRequest: RoutesRequest = {
       // Origin chain
       fromAddress: this.walletAddress,
@@ -70,6 +72,10 @@ export class LiFiProviderService implements OnModuleInit, IRebalanceProvider<'Li
       toAddress: this.walletAddress,
       toChainId: tokenOut.chainId,
       toTokenAddress: tokenOut.config.address,
+    }
+
+    if (routesRequest.fromChainId === routesRequest.toChainId && swapSlippage) {
+      routesRequest.options = { ...routesRequest.options, slippage: swapSlippage }
     }
 
     const result = await getRoutes(routesRequest)


### PR DESCRIPTION
This pull request introduces a new optional configuration parameter, `swapSlippage`, to the liquidity manager and updates its usage in the `LiFiProviderService`. The changes aim to improve flexibility in handling slippage for swaps while maintaining backward compatibility.

### Configuration Updates:
* [`src/eco-configs/eco-config.types.ts`](diffhunk://#diff-31505ba579385f83b176b2bca49832ef2211b592014d5c8fe4f830f04d5f88abR373): Added a new optional `swapSlippage` parameter to the `LiquidityManagerConfig` interface. This parameter allows specifying slippage for swaps separately from the maximum quote slippage.

### Service Logic Adjustments:
* [`src/liquidity-manager/services/liquidity-providers/LiFi/lifi-provider.service.ts`](diffhunk://#diff-d354c3ebe60ba86906b2cddd3c7e82250d2ed4eed674807a180e77c3681faedaL62-R62): Updated the `LiFiProviderService` to use `swapSlippage` instead of `maxQuoteSlippage` when constructing a `RoutesRequest`. This change provides more granular control over slippage settings.
* [`src/liquidity-manager/services/liquidity-providers/LiFi/lifi-provider.service.ts`](diffhunk://#diff-d354c3ebe60ba86906b2cddd3c7e82250d2ed4eed674807a180e77c3681faedaR75-R78): Added logic to conditionally include the `swapSlippage` parameter in `routesRequest.options` when the origin and destination chains are the same and `swapSlippage` is defined. This ensures the new parameter is only applied when relevant.