### PR TITLE
Fix Metalayer prover data encode

### DIFF
--- a/src/intent/wallet-fulfill.service.ts
+++ b/src/intent/wallet-fulfill.service.ts
@@ -322,7 +322,7 @@ export class WalletFulfillService implements IFulfillService {
       [pad(model.intent.reward.prover), '0x', zeroAddress],
     )
 
-    const fee = await this.getProverFee(model, hyperProverAddr, messageData)
+    const fee = await this.getProverFee(model, claimant, hyperProverAddr, messageData)
 
     const fulfillIntentData = encodeFunctionData({
       abi: InboxAbi,
@@ -366,12 +366,12 @@ export class WalletFulfillService implements IFulfillService {
     }
 
     const messageData = encodeAbiParameters(
-      [{ type: 'uint32' }, { type: 'bytes32' }],
-      [Number(model.intent.route.source), pad(model.intent.reward.prover)],
+      [{ type: 'bytes32' }],
+      [pad(model.intent.reward.prover)],
     )
 
     // Metalayer may use the same fee structure as Hyperlane
-    const fee = await this.getProverFee(model, metalayerProverAddr, messageData)
+    const fee = await this.getProverFee(model, claimant, metalayerProverAddr, messageData)
 
     const fulfillIntentData = encodeFunctionData({
       abi: InboxAbi,
@@ -397,12 +397,14 @@ export class WalletFulfillService implements IFulfillService {
    * Calculates the fee required for a transaction by calling the prover contract.
    *
    * @param {IntentSourceModel} model - The model containing intent details, including route, hash, and reward information.
+   * @param claimant - The claimant address
    * @param proverAddr - The address of the prover contract
    * @param messageData - The message data to send
    * @return {Promise<bigint>} A promise that resolves to the fee amount
    */
   private async getProverFee(
     model: IntentSourceModel,
+    claimant: Hex,
     proverAddr: Hex,
     messageData: Hex,
   ): Promise<bigint> {
@@ -416,7 +418,7 @@ export class WalletFulfillService implements IFulfillService {
       args: [
         IntentSourceModel.getSource(model), //_sourceChainID
         [model.intent.hash],
-        [this.ecoConfigService.getEth().claimant],
+        [claimant],
         messageData,
       ],
     })


### PR DESCRIPTION
This pull request updates the `WalletFulfillService` class in `src/intent/wallet-fulfill.service.ts` to include the claimant address as a parameter in several methods and refactors the `getProverFee` method to accommodate this change. The updates improve flexibility and make the claimant address explicitly configurable.

### Updates to method parameters and logic:

* Modified the `getProverFee` method to include a new `claimant` parameter, enabling more dynamic handling of the claimant address.
* Updated calls to `getProverFee` to pass the `claimant` parameter instead of relying on the default claimant address from `ecoConfigService`. [[1]](diffhunk://#diff-42d7ed95df5ff24de12fddcf95c1ed2f0d9b37ebb5ac14cc7afc8b3b19cbe87aL325-R325) [[2]](diffhunk://#diff-42d7ed95df5ff24de12fddcf95c1ed2f0d9b37ebb5ac14cc7afc8b3b19cbe87aL369-R374)

### Refactoring for explicit claimant usage:

* Replaced the default claimant address (`this.ecoConfigService.getEth().claimant`) with the explicitly passed `claimant` parameter in transaction arguments.

### ABI encoding adjustments:

* Simplified the `messageData` encoding structure by removing the `uint32` type and reducing the encoded parameters to only include `bytes32`.