### PR TITLE
Destination prover validation

### DIFF
--- a/src/common/errors/eco-error.ts
+++ b/src/common/errors/eco-error.ts
@@ -71,6 +71,10 @@ export class EcoError extends Error {
     return new Error(`The prover type ${pt} is not supported`)
   }
 
+  static ProverNotAllowed(source: number, destination: number, prover: string) {
+    return new Error(`The prover ${prover} is not supported on route ${source} to ${destination}`)
+  }
+
   static RebalancingRouteNotFound() {
     return new EcoError(`A rebalancing route not found`)
   }

--- a/src/intent/tests/validation.service.spec.ts
+++ b/src/intent/tests/validation.service.spec.ts
@@ -12,6 +12,7 @@ import { EcoConfigService } from '@/eco-configs/eco-config.service'
 import { entries } from 'lodash'
 import { FeeService } from '@/fee/fee.service'
 import { FeeConfigType } from '@/eco-configs/eco-config.types'
+import { ProofType } from '@/contracts'
 jest.mock('@/intent/utils', () => {
   return {
     ...jest.requireActual('@/intent/utils'),
@@ -46,6 +47,10 @@ describe('ValidationService', () => {
     validationService['logger'].log = mockLogLog
 
     jest.spyOn(ecoConfigService, 'getIntentConfigs').mockReturnValueOnce({} as any)
+
+    // Mock proofService methods to return a valid ProofType by default
+    proofService.getProverType.mockReturnValue(ProofType.HYPERLANE)
+    proofService.isIntentExpirationWithinProofMinimumDate.mockReturnValue(true)
   })
 
   afterEach(async () => {
@@ -470,6 +475,10 @@ describe('ValidationService', () => {
         }
         const now = new Date()
         proofService.getProofMinimumDate = jest.fn().mockReturnValueOnce(now)
+
+        // Mock getIntentSources to return empty array to make checkProverWhitelisted return false
+        ecoConfigService.getIntentSources.mockReturnValue([])
+
         validationService[fun] = jest.fn().mockReturnValueOnce(false)
         const validations = await validationService['assertValidations'](intent, solver)
         expect(validations[boolVarName]).toBe(false)

--- a/src/intent/tests/wallet-fulfill.service.spec.ts
+++ b/src/intent/tests/wallet-fulfill.service.spec.ts
@@ -467,6 +467,8 @@ describe('WalletFulfillService', () => {
           calls: [{ target: address1, data: address2 }],
           deadline: '0x2233',
           salt: '0x3344',
+          source: 10,
+          destination: 11,
           getHash: () => '0xccc',
         },
         reward: {
@@ -500,9 +502,15 @@ describe('WalletFulfillService', () => {
         fulfillIntentService['getFulfillTxForMetalayer'] = jest.fn().mockReturnValue(emptyTxs[0])
         await fulfillIntentService['getFulfillIntentTx'](solver.inboxAddress, model as any)
         expect(proofService.isHyperlaneProver).toHaveBeenCalledTimes(1)
-        expect(proofService.isHyperlaneProver).toHaveBeenCalledWith(model.intent.reward.prover)
+        expect(proofService.isHyperlaneProver).toHaveBeenCalledWith(
+          Number(model.intent.route.source),
+          model.intent.reward.prover,
+        )
         expect(proofService.isMetalayerProver).toHaveBeenCalledTimes(1)
-        expect(proofService.isMetalayerProver).toHaveBeenCalledWith(model.intent.reward.prover)
+        expect(proofService.isMetalayerProver).toHaveBeenCalledWith(
+          Number(model.intent.route.source),
+          model.intent.reward.prover,
+        )
         expect(fulfillIntentService['getFulfillTxForMetalayer']).toHaveBeenCalledTimes(1)
       })
 
@@ -526,9 +534,15 @@ describe('WalletFulfillService', () => {
         )
         expect(tx).toEqual(metaproverTx)
         expect(proofService.isHyperlaneProver).toHaveBeenCalledTimes(1)
-        expect(proofService.isHyperlaneProver).toHaveBeenCalledWith(model.intent.reward.prover)
+        expect(proofService.isHyperlaneProver).toHaveBeenCalledWith(
+          Number(model.intent.route.source),
+          model.intent.reward.prover,
+        )
         expect(proofService.isMetalayerProver).toHaveBeenCalledTimes(1)
-        expect(proofService.isMetalayerProver).toHaveBeenCalledWith(model.intent.reward.prover)
+        expect(proofService.isMetalayerProver).toHaveBeenCalledWith(
+          Number(model.intent.route.source),
+          model.intent.reward.prover,
+        )
         expect(fulfillIntentService['getFulfillTxForMetalayer']).toHaveBeenCalledTimes(1)
       })
     })
@@ -542,7 +556,10 @@ describe('WalletFulfillService', () => {
           .mockReturnValue(emptyTxs[0])
         await fulfillIntentService['getFulfillIntentTx'](solver.inboxAddress, model as any)
         expect(proofService.isHyperlaneProver).toHaveBeenCalledTimes(1)
-        expect(proofService.isHyperlaneProver).toHaveBeenCalledWith(model.intent.reward.prover)
+        expect(proofService.isHyperlaneProver).toHaveBeenCalledWith(
+          Number(model.intent.route.source),
+          model.intent.reward.prover,
+        )
         expect(fulfillIntentService['getFulfillTxForHyperproverSingle']).toHaveBeenCalledTimes(1)
       })
 
@@ -569,7 +586,10 @@ describe('WalletFulfillService', () => {
         expect(tx).toEqual(hyperproverTx)
         expect(proofService.isMetalayerProver).toHaveBeenCalledTimes(0)
         expect(proofService.isHyperlaneProver).toHaveBeenCalledTimes(1)
-        expect(proofService.isHyperlaneProver).toHaveBeenCalledWith(model.intent.reward.prover)
+        expect(proofService.isHyperlaneProver).toHaveBeenCalledWith(
+          Number(model.intent.route.source),
+          model.intent.reward.prover,
+        )
         expect(fulfillIntentService['getFulfillTxForHyperproverSingle']).toHaveBeenCalledTimes(1)
       })
 
@@ -593,7 +613,10 @@ describe('WalletFulfillService', () => {
         expect(tx).toEqual(hyperproverTx)
         expect(proofService.isMetalayerProver).toHaveBeenCalledTimes(0)
         expect(proofService.isHyperlaneProver).toHaveBeenCalledTimes(1)
-        expect(proofService.isHyperlaneProver).toHaveBeenCalledWith(model.intent.reward.prover)
+        expect(proofService.isHyperlaneProver).toHaveBeenCalledWith(
+          Number(model.intent.route.source),
+          model.intent.reward.prover,
+        )
         expect(fulfillIntentService['getFulfillTxForHyperproverBatch']).toHaveBeenCalledTimes(1)
       })
     })

--- a/src/intent/validation.sevice.ts
+++ b/src/intent/validation.sevice.ts
@@ -15,8 +15,9 @@ import { QuoteIntentDataInterface } from '@/quote/dto/quote.intent.data.dto'
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common'
 import { difference } from 'lodash'
 import { Hex } from 'viem'
-import { CallDataInterface } from '../contracts'
-import { isGreaterEqual } from '../fee/utils'
+import { isGreaterEqual } from '@/fee/utils'
+import { CallDataInterface } from '@/contracts'
+import { EcoError } from '@/common/errors/eco-error'
 
 interface IntentModelWithHashInterface {
   hash?: Hex
@@ -85,11 +86,13 @@ export class ValidationService implements OnModuleInit {
   onModuleInit() {
     this.isNativeEnabled = this.ecoConfigService.getIntentConfigs().isNativeSupported
   }
+
   /**
    * Executes all the validations we have on the model and solver
    *
    * @param intent the source intent model
    * @param solver the solver for the source chain
+   * @param txValidationFn
    * @returns true if they all pass, false otherwise
    */
   async assertValidations(
@@ -98,8 +101,9 @@ export class ValidationService implements OnModuleInit {
     txValidationFn: TxValidationFn = () => true,
   ): Promise<ValidationChecks> {
     const supportedProver = this.supportedProver({
-      sourceChainID: intent.route.source,
       prover: intent.reward.prover,
+      source: Number(intent.route.source),
+      destination: Number(intent.route.destination),
     })
     const supportedNative = this.supportedNative(intent)
     const supportedTargets = this.supportedTargets(intent, solver)
@@ -122,22 +126,36 @@ export class ValidationService implements OnModuleInit {
   }
 
   /**
-   * Checks if the IntentCreated event is using a supported prover. It first finds the source intent contract that is on the
-   * source chain of the event. Then it checks if the prover is supported by the source intent. In the
-   * case that there are multiple matching source intent contracts on the same chain, as long as any of
-   * them support the prover, the function will return true.
+   * Checks if a given source chain ID and prover are supported within the available intent sources.
    *
-   * @param ops the intent info
-   * @returns
+   * @param {Object} opts - The operation parameters.
+   * @param {bigint} opts.chainID - The ID of the chain to check for support.
+   * @param {Hex} opts.prover - The prover to validate against the intent sources.
+   * @return {boolean} Returns true if the source chain ID and prover are supported, otherwise false.
    */
-  supportedProver(ops: { sourceChainID: bigint; prover: Hex }): boolean {
-    const srcSolvers = this.ecoConfigService.getIntentSources().filter((intent) => {
-      return BigInt(intent.chainID) == ops.sourceChainID
-    })
+  supportedProver(opts: { source: number; destination: number; prover: Hex }): boolean {
+    const isWhitelisted = this.checkProverWhitelisted(opts.source, opts.prover)
 
-    return srcSolvers.some((intent) => {
-      return intent.provers.some((prover) => prover == ops.prover)
-    })
+    if (!isWhitelisted) return false
+
+    const type = this.proofService.getProverType(Number(opts.source), opts.prover)
+
+    switch (true) {
+      case type.isHyperlane():
+      case type.isMetalayer():
+        return this.checkProverWhitelisted(opts.destination, opts.prover)
+      default:
+        throw EcoError.ProverNotAllowed(opts.source, opts.destination, opts.prover)
+    }
+  }
+
+  checkProverWhitelisted(chainID: number, prover: Hex): boolean {
+    return this.ecoConfigService
+      .getIntentSources()
+      .some(
+        (intent) =>
+          intent.chainID === chainID && intent.provers.some((_prover) => _prover == prover),
+      )
   }
 
   /**
@@ -196,6 +214,7 @@ export class ValidationService implements OnModuleInit {
    *
    * @param intent the intent model
    * @param solver the solver for the intent
+   * @param txValidationFn
    * @returns
    */
   supportedTransaction(
@@ -217,6 +236,7 @@ export class ValidationService implements OnModuleInit {
       return tx && txValidationFn(tx)
     })
   }
+
   /**
    * Checks if the transfer total is within the bounds of the solver, ie below a certain threshold
    * @param intent the source intent model
@@ -259,14 +279,17 @@ export class ValidationService implements OnModuleInit {
   /**
    *
    * @param intent the source intent model
-   * @param solver the solver for the source chain
    * @returns
    */
   validExpirationTime(intent: ValidationIntentInterface): boolean {
     //convert to milliseconds
-    const time = Number.parseInt(`${intent.reward.deadline as bigint}`) * 1000
+    const time = Number(intent.reward.deadline * 1000n)
     const expires = new Date(time)
-    return this.proofService.isIntentExpirationWithinProofMinimumDate(intent.reward.prover, expires)
+    return this.proofService.isIntentExpirationWithinProofMinimumDate(
+      Number(intent.route.source),
+      intent.reward.prover,
+      expires,
+    )
   }
 
   /**
@@ -282,7 +305,6 @@ export class ValidationService implements OnModuleInit {
    * Checks that the intent fulfillment is on a different chain than its source
    * Needed since some proving methods(Hyperlane) cant prove same chain
    * @param intent the source intent
-   * @param solver the solver used to fulfill
    * @returns
    */
   fulfillOnDifferentChain(intent: ValidationIntentInterface): boolean {

--- a/src/intent/validation.sevice.ts
+++ b/src/intent/validation.sevice.ts
@@ -140,6 +140,10 @@ export class ValidationService implements OnModuleInit {
 
     const type = this.proofService.getProverType(Number(opts.source), opts.prover)
 
+    if (!type) {
+      return false
+    }
+
     switch (true) {
       case type.isHyperlane():
       case type.isMetalayer():
@@ -283,7 +287,7 @@ export class ValidationService implements OnModuleInit {
    */
   validExpirationTime(intent: ValidationIntentInterface): boolean {
     //convert to milliseconds
-    const time = Number(intent.reward.deadline * 1000n)
+    const time = Number(intent.reward.deadline) * 1000
     const expires = new Date(time)
     return this.proofService.isIntentExpirationWithinProofMinimumDate(
       Number(intent.route.source),

--- a/src/intent/wallet-fulfill.service.ts
+++ b/src/intent/wallet-fulfill.service.ts
@@ -240,13 +240,19 @@ export class WalletFulfillService implements IFulfillService {
     const claimant = this.ecoConfigService.getEth().claimant
 
     // Hyper Prover
-    const isHyperlane = this.proofService.isHyperlaneProver(model.intent.reward.prover)
+    const isHyperlane = this.proofService.isHyperlaneProver(
+      Number(model.intent.route.source),
+      model.intent.reward.prover,
+    )
     if (isHyperlane) {
       return this.getFulfillTxForHyperprover(inboxAddress, claimant, model)
     }
 
     // Metalayer Prover
-    const isMetalayer = this.proofService.isMetalayerProver(model.intent.reward.prover)
+    const isMetalayer = this.proofService.isMetalayerProver(
+      Number(model.intent.route.source),
+      model.intent.reward.prover,
+    )
     if (isMetalayer) {
       return this.getFulfillTxForMetalayer(inboxAddress, claimant, model)
     }

--- a/src/prover/proof.service.ts
+++ b/src/prover/proof.service.ts
@@ -1,13 +1,19 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common'
+import * as _ from 'lodash'
+import { getAddress, Hex } from 'viem'
+import { IProverAbi } from '@eco-foundation/routes-ts'
 import { addSeconds, compareAsc } from 'date-fns'
-import { EcoConfigService } from '@/eco-configs/eco-config.service'
+import { ProofCall, ProofType } from '@/contracts'
 import { EcoError } from '@/common/errors/eco-error'
 import { EcoLogMessage } from '@/common/logging/eco-log-message'
-import { entries } from 'lodash'
-import { getAddress, Hex } from 'viem'
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common'
-import { IProverAbi } from '@eco-foundation/routes-ts'
+import { EcoConfigService } from '@/eco-configs/eco-config.service'
 import { MultichainPublicClientService } from '@/transaction/multichain-public-client.service'
-import { ProofCall, ProofType } from '@/contracts'
+
+interface ProverMetadata {
+  address: Hex
+  type: ProofType
+  chainID: number
+}
 
 /**
  * Service class for getting information about the provers and their configurations.
@@ -20,7 +26,7 @@ export class ProofService implements OnModuleInit {
    * Variable storing the proof type for each prover address. Used to determine
    * what function to call on the Inbox contract
    */
-  private proofContracts: Record<Hex, ProofType> = {}
+  private provers: ProverMetadata[] = []
 
   constructor(
     private readonly publicClient: MultichainPublicClientService,
@@ -32,31 +38,23 @@ export class ProofService implements OnModuleInit {
   }
 
   /**
-   * Returns the proof type for a given prover address
-   *
-   * @param proverAddress
-   * @returns the proof type, defaults to {@link PROOF_STORAGE}
-   */
-  getProofType(proverAddress: Hex): ProofType {
-    return this.proofContracts[proverAddress]
-  }
-
-  /**
    * Checks if the prover is a hyperlane prover
+   * @param chainID
    * @param proverAddress the prover address
    * @returns
    */
-  isHyperlaneProver(proverAddress: Hex): boolean {
-    return this.getProofType(proverAddress).isHyperlane()
+  isHyperlaneProver(chainID: number, proverAddress: Hex): boolean {
+    return this.getProverType(chainID, proverAddress).isHyperlane()
   }
 
   /**
    * Checks if the prover is a metalayer prover
+   * @param chainID
    * @param proverAddress the prover address
    * @returns
    */
-  isMetalayerProver(proverAddress: Hex): boolean {
-    return this.getProofType(proverAddress).isMetalayer()
+  isMetalayerProver(chainID: number, proverAddress: Hex): boolean {
+    return this.getProverType(chainID, proverAddress).isMetalayer()
   }
 
   /**
@@ -65,18 +63,49 @@ export class ProofService implements OnModuleInit {
    * @returns
    */
   getProvers(proofType: ProofType): Hex[] {
-    return entries(this.proofContracts)
-      .filter(([, type]) => type === proofType)
-      .map(([address]) => getAddress(address))
+    const proverAddresses = this.provers
+      .filter((prover) => prover.type === proofType)
+      .map((prover) => getAddress(prover.address))
+
+    return _.uniq(proverAddresses)
   }
 
   /**
    * Returns the prover type for a given prover address
-   * @param prover the prover address
+   * @param chainID
+   * @param proverAddr the prover address
    * @returns
    */
-  getProverType(prover: Hex): ProofType {
-    return this.proofContracts[prover]
+  getProverType(chainID: number, proverAddr: Hex): ProofType {
+    return this.provers.find(
+      (prover) => prover.chainID === chainID && prover.address === proverAddr,
+    )?.[0]
+  }
+
+  /**
+   * Check to see if the expiration of an intent is after the minimum proof time from now.
+   *
+   * @param chainID
+   * @param prover the address of the prover
+   * @param expirationDate the expiration date
+   * @returns true if the intent can be proven before the minimum proof time, false otherwise
+   */
+  isIntentExpirationWithinProofMinimumDate(
+    chainID: number,
+    prover: Hex,
+    expirationDate: Date,
+  ): boolean {
+    const proofType = this.getProverType(chainID, prover)
+    return compareAsc(expirationDate, this.getProofMinimumDate(proofType)) === 1
+  }
+
+  /**
+   * Gets the minimum date that a proof can be generated for a given chain id.
+   * @param prover
+   * @returns
+   */
+  getProofMinimumDate(prover: ProofType): Date {
+    return addSeconds(new Date(), this.getProofMinimumDurationSeconds(prover))
   }
 
   /**
@@ -85,26 +114,20 @@ export class ProofService implements OnModuleInit {
    * hex address is the same.
    */
   private async loadProofTypes() {
-    const proofPromises = this.ecoConfigService.getIntentSources().map(async (source) => {
-      return await this.getProofTypes(source.chainID, source.provers)
-    })
+    const proofPromises = this.ecoConfigService
+      .getIntentSources()
+      .map((source) => this.getProofTypes(source.chainID, source.provers))
 
     // get the proof types for each prover address from on chain
     const proofs = await Promise.all(proofPromises)
 
-    // reduce the array of proof objects into a single object, removing duplicates
-    proofs.reduce((acc, proof) => {
-      entries(proof).forEach(([proverAddress, proofType]) => {
-        acc[proverAddress] = proofType
-      })
-      return acc
-    }, this.proofContracts)
+    this.provers = proofs.flat()
 
     this.logger.debug(
       EcoLogMessage.fromDefault({
         message: `loadProofTypes loaded all the proof types`,
         properties: {
-          proofs: this.proofContracts,
+          proofs: this.provers,
         },
       }),
     )
@@ -117,19 +140,17 @@ export class ProofService implements OnModuleInit {
    * @param provers the prover addresses
    * @returns
    */
-  private async getProofTypes(chainID: number, provers: Hex[]): Promise<Record<Hex, ProofType>> {
+  private async getProofTypes(chainID: number, provers: Hex[]): Promise<ProverMetadata[]> {
     const client = await this.publicClient.getClient(Number(chainID))
-    const proofCalls: ProofCall[] = provers.map((proverAddress) => {
-      return {
-        address: proverAddress,
-        abi: IProverAbi,
-        functionName: 'getProofType',
-      }
-    })
+    const proofCalls: ProofCall[] = provers.map((proverAddress) => ({
+      address: proverAddress,
+      abi: IProverAbi,
+      functionName: 'getProofType',
+    }))
 
     const proofTypeResults = await client.multicall({ contracts: proofCalls })
 
-    const proofObj: Record<Hex, ProofType> = {}
+    const proofs: ProverMetadata[] = []
 
     for (const proverIndex in provers) {
       const proverAddr = provers[proverIndex]
@@ -150,31 +171,15 @@ export class ProofService implements OnModuleInit {
       }
 
       if (proofType) {
-        proofObj[proverAddr] = this.getProofTypeFromString(proofType!)
+        proofs.push({
+          chainID,
+          address: proverAddr,
+          type: this.getProofTypeFromString(proofType),
+        })
       }
     }
 
-    return proofObj
-  }
-
-  /**
-   * Check to see if the expiration of an intent is after the minimum proof time from now.
-   *
-   * @param prover the address of the prover
-   * @param expirationDate the expiration date
-   * @returns true if the intent can be proven before the minimum proof time, false otherwise
-   */
-  isIntentExpirationWithinProofMinimumDate(prover: Hex, expirationDate: Date): boolean {
-    return compareAsc(expirationDate, this.getProofMinimumDate(this.proofContracts[prover])) == 1
-  }
-
-  /**
-   * Gets the minimum date that a proof can be generated for a given chain id.
-   * @param prover
-   * @returns
-   */
-  getProofMinimumDate(prover: ProofType): Date {
-    return addSeconds(new Date(), this.getProofMinimumDurationSeconds(prover))
+    return proofs
   }
 
   /**

--- a/src/prover/proof.service.ts
+++ b/src/prover/proof.service.ts
@@ -44,7 +44,7 @@ export class ProofService implements OnModuleInit {
    * @returns
    */
   isHyperlaneProver(chainID: number, proverAddress: Hex): boolean {
-    return this.getProverType(chainID, proverAddress).isHyperlane()
+    return Boolean(this.getProverType(chainID, proverAddress)?.isHyperlane())
   }
 
   /**
@@ -54,7 +54,7 @@ export class ProofService implements OnModuleInit {
    * @returns
    */
   isMetalayerProver(chainID: number, proverAddress: Hex): boolean {
-    return this.getProverType(chainID, proverAddress).isMetalayer()
+    return Boolean(this.getProverType(chainID, proverAddress)?.isMetalayer())
   }
 
   /**
@@ -76,10 +76,10 @@ export class ProofService implements OnModuleInit {
    * @param proverAddr the prover address
    * @returns
    */
-  getProverType(chainID: number, proverAddr: Hex): ProofType {
+  getProverType(chainID: number, proverAddr: Hex): ProofType | undefined {
     return this.provers.find(
       (prover) => prover.chainID === chainID && prover.address === proverAddr,
-    )?.[0]
+    )?.type
   }
 
   /**
@@ -96,6 +96,9 @@ export class ProofService implements OnModuleInit {
     expirationDate: Date,
   ): boolean {
     const proofType = this.getProverType(chainID, prover)
+    if (!proofType) {
+      return false
+    }
     return compareAsc(expirationDate, this.getProofMinimumDate(proofType)) === 1
   }
 


### PR DESCRIPTION
  This PR adds validation for provers on the destination chain, ensuring that cross-chain provers (Hyperlane and Metalayer) are properly whitelisted on both source and destination chains.

  Changes

  - Enhanced prover validation: Added destination chain validation for Hyperlane and Metalayer provers in ValidationService.supportedProver()
  - Refactored proof service: Updated ProofService to store prover metadata per chain, allowing chain-specific prover type lookups
  - Added error handling: New ProverNotAllowed error for unsupported prover/route combinations
  - Fixed type safety: Updated method signatures to include chainID parameter for prover-related operations

  Breaking Changes

  - ProofService.isHyperlaneProver() now requires chainID as first parameter
  - ProofService.isMetalayerProver() now requires chainID as first parameter
  - ProofService.getProverType() now requires chainID as first parameter
  - ProofService.isIntentExpirationWithinProofMinimumDate() now requires chainID as first parameter

  Testing

  - Updated all affected unit tests to match new method signatures
  - Fixed mock data structures in test files
  - All tests passing