### PR TITLE
Use Railway indexer on prod

### DIFF
--- a/config/production.ts
+++ b/config/production.ts
@@ -3,6 +3,10 @@ export default {
     url: 'https://solver.prod.bend.eco',
   },
 
+  indexer: {
+    url: 'https://protocol-indexer-production.up.railway.app',
+  },
+
   aws: [
     {
       region: 'us-east-2',


### PR DESCRIPTION
This pull request introduces a new configuration for the production environment by adding an `indexer` service URL to the `config/production.ts` file.

* [`config/production.ts`](diffhunk://#diff-1ad631663da89ea53f676d4b5675fb733f54a6e7c888198ac4dcd468e9732937R6-R9): Added a new `indexer` configuration with a URL pointing to `https://protocol-indexer-production.up.railway.app`.