### PR TITLE
Solver prod url

### DIFF
--- a/config/production.ts
+++ b/config/production.ts
@@ -1,6 +1,6 @@
 export default {
   server: {
-    url: 'https://solver.prod.bend.eco',
+    url: 'https://solver.bend.eco',
   },
 
   indexer: {


### PR DESCRIPTION
This pull request includes a small change to the `config/production.ts` file. The change updates the server URL to remove the `.prod` subdomain, simplifying the URL for the production environment.