### PR TITLE
Fix serialization if input is a BigInt

### DIFF
--- a/src/common/utils/serialize.spec.ts
+++ b/src/common/utils/serialize.spec.ts
@@ -21,4 +21,14 @@ describe('Serialize BigInt', () => {
 
     expect(typeof objDeserialized.bigInt).toBe('bigint')
   })
+
+  it('deserialize bigint correctly', () => {
+    const obj = {
+      type: 'BigInt',
+      hex: '0x5f57eac89ced72',
+    }
+    const objDeserialized = deserialize(obj)
+
+    expect(objDeserialized).toBe(26836788687203698n)
+  })
 })


### PR DESCRIPTION
This pull request enhances the serialization and deserialization of `bigint` values in the `src/common/utils` module. It introduces functionality to handle `bigint` types more robustly, ensuring they are serialized into a specific format and correctly deserialized back into `bigint`.

### Enhancements to `bigint` serialization and deserialization:

* **Added support for `bigint` in `Serialize` type**: Updated the `Serialize<T>` type to include a specific format for `bigint`, using an object with a `type` field set to `'BigInt'` and a hexadecimal representation in the `hex` field. (`src/common/utils/serialize.ts`, [src/common/utils/serialize.tsL3-R5](diffhunk://#diff-b0d05e4cbd82a2873a48f3780a7417e9691db2920f59d29db944e66b69bd2549L3-R5))

* **Improved `deserialize` function**: Modified the `deserialize` function to handle both `bigint` and objects. Added logic to recognize serialized `bigint` objects and convert them back into `bigint` values using the `BigInt` constructor. (`src/common/utils/serialize.ts`, [src/common/utils/serialize.tsL26-R35](diffhunk://#diff-b0d05e4cbd82a2873a48f3780a7417e9691db2920f59d29db944e66b69bd2549L26-R35))

### Testing updates:

* **Added test for `bigint` deserialization**: Introduced a new test case in the `serialize.spec.ts` file to ensure that a serialized `bigint` object is correctly deserialized into its original `bigint` value. (`src/common/utils/serialize.spec.ts`, [src/common/utils/serialize.spec.tsR24-R33](diffhunk://#diff-f68eb76c63937ed31b5ee9dd72d78e01f103c79e0e425a4a8f620ab417e867f6R24-R33))