### PR TITLE
Add retry logic to intent funded validation

### DIFF
--- a/config/default.ts
+++ b/config/default.ts
@@ -117,6 +117,8 @@ export default {
       hyperlane_duration_seconds: 3600,
       metalayer_duration_seconds: 7200,
     },
+    intentFundedRetries: 3,
+    intentFundedRetryDelayMs: 500,
   },
   whitelist: {},
 

--- a/src/common/utils/time.ts
+++ b/src/common/utils/time.ts
@@ -1,0 +1,2 @@
+export const delay = (ms: number, i: number = 0) =>
+  new Promise((res) => setTimeout(res, ms * Math.pow(2, i)))

--- a/src/eco-configs/eco-config.types.ts
+++ b/src/eco-configs/eco-config.types.ts
@@ -152,6 +152,8 @@ export type IntentConfig = {
     metalayer_duration_seconds: number
   }
   isNativeETHSupported: boolean
+  intentFundedRetries: number
+  intentFundedRetryDelayMs: number
 }
 
 /**

--- a/src/intent/validate-intent.service.ts
+++ b/src/intent/validate-intent.service.ts
@@ -1,20 +1,20 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common'
-import { EcoConfigService } from '../eco-configs/eco-config.service'
-import { EcoLogMessage } from '../common/logging/eco-log-message'
-import { IntentProcessData, UtilsIntentService } from './utils-intent.service'
-import { QUEUES } from '../common/redis/constants'
+import { Hex } from 'viem'
 import { JobsOptions, Queue } from 'bullmq'
 import { InjectQueue } from '@nestjs/bullmq'
-import { getIntentJobId } from '../common/utils/strings'
-import { Solver } from '../eco-configs/eco-config.types'
-import { IntentSourceModel } from './schemas/intent-source.schema'
-import { Hex } from 'viem'
-import { EcoError } from '../common/errors/eco-error'
-import { ValidationChecks, ValidationService, validationsFailed } from '@/intent/validation.sevice'
-import { MultichainPublicClientService } from '@/transaction/multichain-public-client.service'
 import { IntentSourceAbi } from '@eco-foundation/routes-ts'
-import { IntentDataModel } from '@/intent/schemas/intent-data.schema'
+import { Solver } from '@/eco-configs/eco-config.types'
+import { EcoConfigService } from '@/eco-configs/eco-config.service'
+import { IntentProcessData, UtilsIntentService } from './utils-intent.service'
 import { delay } from '@/common/utils/time'
+import { QUEUES } from '@/common/redis/constants'
+import { EcoError } from '@/common/errors/eco-error'
+import { getIntentJobId } from '@/common/utils/strings'
+import { EcoLogMessage } from '@/common/logging/eco-log-message'
+import { IntentSourceModel } from './schemas/intent-source.schema'
+import { MultichainPublicClientService } from '@/transaction/multichain-public-client.service'
+import { IntentDataModel } from '@/intent/schemas/intent-data.schema'
+import { ValidationChecks, ValidationService, validationsFailed } from '@/intent/validation.sevice'
 
 /**
  * Type that merges the {@link ValidationChecks} with the intentFunded check
@@ -158,44 +158,36 @@ export class ValidateIntentService implements OnModuleInit {
       return false
     }
 
-    const isIntentFunded = await client.readContract({
-      address: intentSource.sourceAddress,
-      abi: IntentSourceAbi,
-      functionName: 'isIntentFunded',
-      args: [IntentDataModel.toChainIntent(model.intent)],
-    })
+    let retryCount = 0
+    let isIntentFunded = false
 
-    if (isIntentFunded) {
-      return true
-    }
+    do {
+      // Add delay for retries (skip delay on first attempt)
+      if (retryCount > 0) {
+        await delay(this.RETRY_DELAY_MS, retryCount - 1)
 
-    // Retry if the intent is not funded
-    for (let i = 0; i < this.MAX_RETRIES; i++) {
-      await delay(this.RETRY_DELAY_MS, i)
+        this.logger.debug(
+          EcoLogMessage.fromDefault({
+            message: `intentFunded check failed, retrying... (${retryCount}/${this.MAX_RETRIES})`,
+            properties: {
+              intentHash: model.intent.hash,
+            },
+          }),
+        )
+      }
 
-      this.logger.debug(
-        EcoLogMessage.fromDefault({
-          message: `intentFunded check failed, retrying... (${i + 1}/${this.MAX_RETRIES})`,
-          properties: {
-            intentHash: model.intent.hash,
-          },
-        }),
-      )
-
-      // Check if the intent is funded again
-      const isIntentFunded = await client.readContract({
+      // Check if the intent is funded
+      isIntentFunded = await client.readContract({
         address: intentSource.sourceAddress,
         abi: IntentSourceAbi,
         functionName: 'isIntentFunded',
         args: [IntentDataModel.toChainIntent(model.intent)],
       })
 
-      if (isIntentFunded) {
-        return true
-      }
-    }
+      retryCount++
+    } while (!isIntentFunded && retryCount <= this.MAX_RETRIES)
 
-    return false
+    return isIntentFunded
   }
 
   /**


### PR DESCRIPTION
Resolves an issue where the `intentFunded` validation was failing intermittently due to a race condition. The on-chain check was being performed before the queried RPC node's state had updated to reflect the funded intent, causing valid intents to be marked as unfunded.

This change introduces a retry mechanism with exponential backoff to the `intentFunded` method in the `ValidateIntentService`.

- The `intentFunded` check will now retry if the initial check fails.
- An exponential backoff strategy is used for the delay between retries.
- The number of retries and the base delay are configurable via `EcoConfigService.intentConfigs`.

```
 intentConfigs: {
    // ...
    intentFundedRetries: 3,
    intentFundedRetryDelayMs: 500,
  },

```

https://eco.atlassian.net/browse/ED-5616