### PR TITLE
Upgrade routes package to v2.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
   "dependencies": {
     "@aws-sdk/client-kms": "^3.744.0",
     "@aws-sdk/client-secrets-manager": "^3.592.0",
-    "@eco-foundation/chains": "1.0.39",
-    "@eco-foundation/routes-ts": "^2.8.3",
+    "@eco-foundation/chains": "1.0.40",
+    "@eco-foundation/routes-ts": "^2.8.4",
     "@launchdarkly/node-server-sdk": "^9.7.1",
     "@liaoliaots/nestjs-redis-health": "^9.0.4",
     "@lifi/sdk": "^3.6.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1472,18 +1472,18 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@eco-foundation/chains@1.0.39":
-  version "1.0.39"
-  resolved "https://registry.yarnpkg.com/@eco-foundation/chains/-/chains-1.0.39.tgz#90da14e31c46bf058be39161f446a4f3136f8a85"
-  integrity sha512-UMmaqi+1HdL6xr0bipkxSexK5FkRTV3pb94w9hnQhZJiEDARBTTLWVSdLVTdImgpGsqYfm1y91uIO2dTBS/mtQ==
+"@eco-foundation/chains@1.0.40":
+  version "1.0.40"
+  resolved "https://registry.yarnpkg.com/@eco-foundation/chains/-/chains-1.0.40.tgz#5730083ce8253039056f5ef92567cbad3bb07619"
+  integrity sha512-PCXXLxPgTmmg608mcqoYFY0VTwlewsYjV5D/tCTs2XIbWhp7O4jYlzYdO/tHeK67qaWkzHXCRsEB4ZXWZczSAw==
   dependencies:
     typia "^8.0.4"
     viem "^2.24.1"
 
-"@eco-foundation/routes-ts@^2.8.3":
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/@eco-foundation/routes-ts/-/routes-ts-2.8.3.tgz#4b68011d8fb443b67f1ad6d149a91f16a30f8eeb"
-  integrity sha512-yBtokUCwMtI6+4zNk66VVRz9TlAwnsgH4b2c95421d2c20MZ3fg4TSr+H/dZhfCY1Shsz3PE+SaXcfp21yQgHw==
+"@eco-foundation/routes-ts@^2.8.4":
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/@eco-foundation/routes-ts/-/routes-ts-2.8.4.tgz#90fbdb426f5b4c0a539f28c9a4a3e65ee5b4b95e"
+  integrity sha512-6WeVyfAhY9WhIWzy0ghr/ZfKwfsyYSuVyeuNtG0dkEZs+L0/X5DhF8zpnxFUPECKw/id6Mso1hd5cC8/sHMOyQ==
   dependencies:
     viem "^2.22.21"
 


### PR DESCRIPTION
This pull request updates the dependencies in the `package.json` file to ensure compatibility with the latest versions of the `@eco-foundation` packages.

Dependency updates:

* Updated `@eco-foundation/chains` from version `1.0.39` to `1.0.40`.
* Updated `@eco-foundation/routes-ts` from version `^2.8.3` to `^2.8.4`.