### PR TITLE
Add support for Viem's fallback transport

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@0xsquid/squid-types": "^0.1.163",
     "@aws-sdk/client-kms": "^3.744.0",
     "@aws-sdk/client-secrets-manager": "^3.592.0",
-    "@eco-foundation/chains": "1.0.40",
+    "@eco-foundation/chains": "1.0.41",
     "@eco-foundation/routes-ts": "^2.8.4",
     "@launchdarkly/node-server-sdk": "^9.7.1",
     "@liaoliaots/nestjs-redis-health": "^9.0.4",

--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
     "@web3-kms-signer/core": "1.0.6",
     "@web3-kms-signer/kms-provider-aws": "1.0.6",
     "@web3-kms-signer/kms-wallets": "1.0.6",
-    "@zerodev/ecdsa-validator": "^5.4.5",
-    "@zerodev/sdk": "^5.4.28",
+    "@zerodev/ecdsa-validator": "^5.4.9",
+    "@zerodev/sdk": "^5.4.40",
     "abitype": "^1.0.8",
     "asn1js": "^3.0.5",
     "axios": "0.21.4",
@@ -88,14 +88,14 @@
     "mongoose": "^8.9.5",
     "nest-commander": "^3.17.0",
     "nestjs-pino": "^4.1.0",
-    "permissionless": "^0.2.39",
+    "permissionless": "^0.2.49",
     "pino-http": "^10.2.0",
     "redlock": "^5.0.0-beta.2",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
     "table": "^6.8.2",
     "uuid": "^11.0.5",
-    "viem": "^2.25.0"
+    "viem": "^2.31.7"
   },
   "devDependencies": {
     "@golevelup/ts-jest": "^0.5.0",

--- a/src/common/chains/tests/transport.spec.ts
+++ b/src/common/chains/tests/transport.spec.ts
@@ -1,0 +1,95 @@
+import { fallback, http, webSocket } from 'viem'
+import { getTransport } from '../transport'
+
+jest.mock('viem', () => ({
+  ...jest.requireActual('viem'),
+  http: jest.fn(),
+  webSocket: jest.fn(),
+  fallback: jest.fn(),
+}))
+
+describe('getTransport', () => {
+  const mockHttpTransport = { type: 'http' }
+  const mockWsTransport = { type: 'ws' }
+  const mockFallbackTransport = { type: 'fallback' }
+
+  beforeEach(() => {
+    ;(http as jest.Mock).mockClear().mockReturnValue(mockHttpTransport)
+    ;(webSocket as jest.Mock).mockClear().mockReturnValue(mockWsTransport)
+    ;(fallback as jest.Mock).mockClear().mockReturnValue(mockFallbackTransport)
+  })
+
+  it('should return a single http transport for a single http rpc url', () => {
+    const rpcUrls = ['http://test.rpc']
+    const transport = getTransport(rpcUrls)
+
+    expect(http).toHaveBeenCalledWith(rpcUrls[0], undefined)
+    expect(http).toHaveBeenCalledTimes(1)
+    expect(webSocket).not.toHaveBeenCalled()
+    expect(fallback).not.toHaveBeenCalled()
+    expect(transport).toEqual(mockHttpTransport)
+  })
+
+  it('should return a fallback transport for multiple http rpc urls', () => {
+    const rpcUrls = ['http://test.rpc', 'http://test2.rpc']
+    const transport = getTransport(rpcUrls)
+
+    expect(http).toHaveBeenCalledTimes(2)
+    expect(http).toHaveBeenCalledWith(rpcUrls[0], undefined)
+    expect(http).toHaveBeenCalledWith(rpcUrls[1], undefined)
+    expect(webSocket).not.toHaveBeenCalled()
+    expect(fallback).toHaveBeenCalledTimes(1)
+    expect(fallback).toHaveBeenCalledWith([mockHttpTransport, mockHttpTransport], { rank: true })
+    expect(transport).toEqual(mockFallbackTransport)
+  })
+
+  it('should return a single websocket transport for a single websocket rpc url', () => {
+    const rpcUrls = ['ws://test.rpc']
+    const transport = getTransport(rpcUrls, { isWebsocket: true })
+
+    expect(webSocket).toHaveBeenCalledWith(rpcUrls[0], { keepAlive: true, reconnect: true })
+    expect(webSocket).toHaveBeenCalledTimes(1)
+    expect(http).not.toHaveBeenCalled()
+    expect(fallback).not.toHaveBeenCalled()
+    expect(transport).toEqual(mockWsTransport)
+  })
+
+  it('should return a fallback transport for multiple websocket rpc urls', () => {
+    const rpcUrls = ['ws://test.rpc', 'ws://test2.rpc']
+    const transport = getTransport(rpcUrls, { isWebsocket: true })
+
+    expect(webSocket).toHaveBeenCalledTimes(2)
+    expect(webSocket).toHaveBeenCalledWith(rpcUrls[0], { keepAlive: true, reconnect: true })
+    expect(webSocket).toHaveBeenCalledWith(rpcUrls[1], { keepAlive: true, reconnect: true })
+    expect(http).not.toHaveBeenCalled()
+    expect(fallback).toHaveBeenCalledTimes(1)
+    expect(fallback).toHaveBeenCalledWith([mockWsTransport, mockWsTransport], { rank: true })
+    expect(transport).toEqual(mockFallbackTransport)
+  })
+
+  it('should pass http config to http transport', () => {
+    const rpcUrls = ['http://test.rpc']
+    const config = { config: { timeout: 1000 } }
+    getTransport(rpcUrls, config)
+    expect(http).toHaveBeenCalledWith(rpcUrls[0], config.config)
+  })
+
+  it('should pass websocket config to websocket transport', () => {
+    const rpcUrls = ['ws://test.rpc']
+    const config = { isWebsocket: true, config: { key: 'test' } } as const
+    getTransport(rpcUrls, config)
+    expect(webSocket).toHaveBeenCalledWith(rpcUrls[0], {
+      keepAlive: true,
+      reconnect: true,
+      ...config.config,
+    })
+  })
+
+  it('should handle an empty array of rpcUrls', () => {
+    const transport = getTransport([])
+    expect(transport).toBeUndefined()
+    expect(http).not.toHaveBeenCalled()
+    expect(webSocket).not.toHaveBeenCalled()
+    expect(fallback).not.toHaveBeenCalled()
+  })
+})

--- a/src/eco-configs/tests/eco-config.service.spec.ts
+++ b/src/eco-configs/tests/eco-config.service.spec.ts
@@ -200,4 +200,101 @@ describe('Eco Config Helper Tests', () => {
       expect(mockgetChainConfig).toHaveBeenCalledWith(mockSolver.chainID)
     })
   })
+
+  describe('getRpcUrls', () => {
+    const mockChain = { id: 1, name: 'test-chain' } as any
+    const mockRpcConfig = {
+      keys: { '1': 'key' },
+      config: { webSockets: true },
+      custom: {},
+    }
+
+    beforeEach(() => {
+      // Mock the necessary config values
+      jest.spyOn(ecoConfigService, 'getRpcConfig').mockReturnValue(mockRpcConfig as any)
+      // Mock the ecoChains object and its getChain method
+      const mockEcoChains = {
+        getChain: jest.fn().mockReturnValue({
+          rpcUrls: {
+            default: {
+              http: ['http://default-rpc.com'],
+              webSocket: ['ws://default-ws.com'],
+            },
+            custom: {},
+          },
+        }),
+      }
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      ecoConfigService.ecoChains = mockEcoChains
+    })
+
+    it('should return default websocket urls', () => {
+      const { rpcUrls, config } = ecoConfigService.getRpcUrls(mockChain)
+      expect(rpcUrls).toEqual(['ws://default-ws.com'])
+      expect(config.isWebsocket).toBe(true)
+    })
+
+    it('should return default http urls when websockets are disabled', () => {
+      jest
+        .spyOn(ecoConfigService, 'getRpcConfig')
+        .mockReturnValue({ ...mockRpcConfig, config: { webSockets: false } } as any)
+      const { rpcUrls, config } = ecoConfigService.getRpcUrls(mockChain)
+      expect(rpcUrls).toEqual(['http://default-rpc.com'])
+      expect(config.isWebsocket).toBe(false)
+    })
+
+    it('should return custom rpc urls if available', () => {
+      const customRpc = {
+        http: ['http://custom-rpc.com'],
+        webSocket: ['ws://custom-ws.com'],
+      }
+      jest.spyOn(ecoConfigService, 'getCustomRPCUrl').mockReturnValue(customRpc as any)
+
+      const { rpcUrls, config } = ecoConfigService.getRpcUrls(mockChain)
+      expect(rpcUrls).toEqual(customRpc.webSocket)
+      expect(config.isWebsocket).toBe(true)
+    })
+
+    it('should use custom http urls if websocket urls are not available in custom config', () => {
+      const customRpc = {
+        http: ['http://custom-rpc.com'],
+      }
+      jest.spyOn(ecoConfigService, 'getCustomRPCUrl').mockReturnValue(customRpc as any)
+
+      const { rpcUrls, config } = ecoConfigService.getRpcUrls(mockChain)
+      expect(rpcUrls).toEqual(customRpc.http)
+      expect(config.isWebsocket).toBe(false)
+    })
+
+    it('should pass through transport config from custom rpc config', () => {
+      const customRpc = {
+        http: ['http://custom-rpc.com'],
+        config: { timeout: 5000 },
+      }
+      jest.spyOn(ecoConfigService, 'getCustomRPCUrl').mockReturnValue(customRpc as any)
+
+      const { config } = ecoConfigService.getRpcUrls(mockChain)
+      expect(config.config).toEqual(customRpc.config)
+    })
+
+    it('should throw an error if no rpc urls are found', () => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      ecoConfigService.ecoChains.getChain = jest.fn().mockReturnValue({
+        rpcUrls: {
+          default: {}, // No default URLs
+          custom: {},
+        },
+      })
+      jest.spyOn(ecoConfigService, 'getCustomRPCUrl').mockReturnValue({} as any)
+      jest
+        .spyOn(ecoConfigService, 'getRpcConfig')
+        .mockReturnValue({ ...mockRpcConfig, config: { webSockets: false } } as any)
+
+      expect(() => ecoConfigService.getRpcUrls(mockChain)).toThrow(
+        `Chain rpc not found for chain ${mockChain.id}`,
+      )
+    })
+  })
 })

--- a/src/liquidity-manager/services/liquidity-providers/LiFi/lifi-provider.service.spec.ts
+++ b/src/liquidity-manager/services/liquidity-providers/LiFi/lifi-provider.service.spec.ts
@@ -89,7 +89,7 @@ describe('LiFiProviderService', () => {
 
       jest.spyOn(ecoConfigService, 'getIntentSources').mockReturnValue([{ chainID: 10 }] as any)
 
-      const rpcUrls = { '10': 'http://op.rpc.com' }
+      const rpcUrls = { '10': ['http://op.rpc.com'] }
       jest.spyOn(ecoConfigService, 'getChainRpcs').mockReturnValue(rpcUrls)
 
       await lifiProviderService.onModuleInit()
@@ -110,7 +110,7 @@ describe('LiFiProviderService', () => {
       mockGetClient.mockReturnValue({ account: { address: '0x123' } } as any)
 
       jest.spyOn(ecoConfigService, 'getIntentSources').mockReturnValue([{ chainID: 10 }] as any)
-      jest.spyOn(ecoConfigService, 'getChainRpcs').mockReturnValue({ '10': 'http://op.rpc.com' })
+      jest.spyOn(ecoConfigService, 'getChainRpcs').mockReturnValue({ '10': ['http://op.rpc.com'] })
 
       // Mock cache initialization failure
       mockAssetCacheManager.initialize.mockRejectedValue(new Error('Cache init failed'))

--- a/src/sign/nonce.service.ts
+++ b/src/sign/nonce.service.ts
@@ -54,8 +54,8 @@ export class NonceService extends AtomicNonceService<Nonce> implements OnApplica
     const paramsAsync = entries(this.ecoConfigService.getSolvers()).map(async ([chainIdString]) => {
       const chainID = parseInt(chainIdString)
       const chain = extractChain({ chains: ChainsSupported, id: chainID })
-      const { rpcUrl, config } = this.ecoConfigService.getRpcUrl(chain)
-      const transport = getTransport(rpcUrl, config)
+      const { rpcUrls, config } = this.ecoConfigService.getRpcUrls(chain)
+      const transport = getTransport(rpcUrls, config)
       const client = createPublicClient({ chain, transport })
       return { address, client } as AtomicKeyClientParams
     })

--- a/src/transaction/smart-wallets/kernel/create.kernel.account.ts
+++ b/src/transaction/smart-wallets/kernel/create.kernel.account.ts
@@ -81,7 +81,7 @@ export async function createKernelAccountClient<
     kernelVersion,
   })
 
-  const kernelAccount = await createKernelAccount(walletClient, {
+  const kernelAccount = await createKernelAccount(walletClient as any, {
     plugins: {
       sudo: ecdsaValidator,
     },

--- a/src/transaction/viem_multichain_client.service.ts
+++ b/src/transaction/viem_multichain_client.service.ts
@@ -51,9 +51,9 @@ export class ViemMultichainClientService<T extends Client, V extends ClientConfi
 
   protected async buildChainConfig(chain: Chain): Promise<V> {
     //only pass api key if chain is supported by alchemy, otherwise it'll be incorrectly added to other rpcs
-    const { rpcUrl, config } = this.ecoConfigService.getRpcUrl(chain)
+    const { rpcUrls, config } = this.ecoConfigService.getRpcUrls(chain)
 
-    const rpcTransport = getTransport(rpcUrl, config)
+    const rpcTransport = getTransport(rpcUrls, config)
     return {
       transport: rpcTransport,
       chain: chain,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1639,13 +1639,13 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@eco-foundation/chains@1.0.40":
-  version "1.0.40"
-  resolved "https://registry.yarnpkg.com/@eco-foundation/chains/-/chains-1.0.40.tgz#5730083ce8253039056f5ef92567cbad3bb07619"
-  integrity sha512-PCXXLxPgTmmg608mcqoYFY0VTwlewsYjV5D/tCTs2XIbWhp7O4jYlzYdO/tHeK67qaWkzHXCRsEB4ZXWZczSAw==
+"@eco-foundation/chains@1.0.41":
+  version "1.0.41"
+  resolved "https://registry.yarnpkg.com/@eco-foundation/chains/-/chains-1.0.41.tgz#1db0787412129750aa2fb8dc5d90ef4d69c3ed2b"
+  integrity sha512-kjrJgBcG0bUgH86dmVjv2XkyoYRCTDNDB2iSsM9RSG69tpJsylMAG2gUrGHvhfOgDv1QFzLTNK7IW17frQp8Ew==
   dependencies:
     typia "^8.0.4"
-    viem "^2.24.1"
+    viem "^2.31.7"
 
 "@eco-foundation/routes-ts@^2.8.4":
   version "2.8.4"
@@ -3385,13 +3385,6 @@
   dependencies:
     "@noble/hashes" "1.7.1"
 
-"@noble/curves@1.8.2":
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.8.2.tgz#8f24c037795e22b90ae29e222a856294c1d9ffc7"
-  integrity sha512-vnI7V6lFNe0tLAuJMu+2sX+FcL14TaCWy1qiczg1VwRmPrpQCdq5ESXQMqUc2tluRNf6irBXrWbl1mGN8uaU/g==
-  dependencies:
-    "@noble/hashes" "1.7.2"
-
 "@noble/curves@1.9.2", "@noble/curves@^1.9.1", "@noble/curves@~1.9.0":
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.9.2.tgz#73388356ce733922396214a933ff7c95afcef911"
@@ -3405,13 +3398,6 @@
   integrity sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==
   dependencies:
     "@noble/hashes" "1.6.0"
-
-"@noble/curves@~1.9.0":
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.9.2.tgz#73388356ce733922396214a933ff7c95afcef911"
-  integrity sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g==
-  dependencies:
-    "@noble/hashes" "1.8.0"
 
 "@noble/hashes@1.3.2":
   version "1.3.2"
@@ -3438,12 +3424,7 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.7.1.tgz#5738f6d765710921e7a751e00c20ae091ed8db0f"
   integrity sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==
 
-"@noble/hashes@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.7.2.tgz#d53c65a21658fb02f3303e7ee3ba89d6754c64b4"
-  integrity sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ==
-
-"@noble/hashes@1.8.0", "@noble/hashes@^1.8.0", "@noble/hashes@~1.8.0":
+"@noble/hashes@1.8.0", "@noble/hashes@^1", "@noble/hashes@^1.8.0", "@noble/hashes@~1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
@@ -3622,11 +3603,6 @@
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.4.tgz#002eb571a35d69bdb4c214d0995dff76a8dcd2a9"
   integrity sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==
 
-"@scure/base@~1.2.5":
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.6.tgz#ca917184b8231394dd8847509c67a0be522e59f6"
-  integrity sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==
-
 "@scure/bip32@1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.4.0.tgz#4e1f1e196abedcef395b33b9674a042524e20d67"
@@ -3645,7 +3621,7 @@
     "@noble/hashes" "~1.7.1"
     "@scure/base" "~1.2.2"
 
-"@scure/bip32@1.7.0", "@scure/bip32@^1.7.0":
+"@scure/bip32@1.7.0", "@scure/bip32@^1.4.0", "@scure/bip32@^1.7.0":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.7.0.tgz#b8683bab172369f988f1589640e53c4606984219"
   integrity sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==
@@ -3679,7 +3655,7 @@
     "@noble/hashes" "~1.7.1"
     "@scure/base" "~1.2.4"
 
-"@scure/bip39@1.6.0", "@scure/bip39@^1.6.0":
+"@scure/bip39@1.6.0", "@scure/bip39@^1.3.0", "@scure/bip39@^1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.6.0.tgz#475970ace440d7be87a6086cbee77cb8f1a684f9"
   integrity sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==
@@ -6643,7 +6619,6 @@ commander@11.1.0:
   integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
 
 commander@4.1.1, commander@^4.0.0:
-commander@4.1.1, commander@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
@@ -7158,14 +7133,6 @@ enumify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmmirror.com/enumify/-/enumify-2.0.0.tgz#7b079efa0ce2a4ebf1a8da24c4544000db41af3e"
   integrity sha512-hpyRdixXrBdr1sZOWH/WKBleMtHWVbM+DyVa0OqKQnKEw6x0TuUNYjcWKlp5/+tdiOsbgYiaZ/pYUeMake4k8A==
-
-env-cmd@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/env-cmd/-/env-cmd-10.1.0.tgz#c7f5d3b550c9519f137fdac4dd8fb6866a8c8c4b"
-  integrity sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==
-  dependencies:
-    commander "^4.0.0"
-    cross-spawn "^7.0.0"
 
 env-cmd@^10.1.0:
   version "10.1.0"
@@ -11854,20 +11821,6 @@ viem@^2.22.21:
     ox "0.6.9"
     ws "8.18.1"
 
-viem@^2.24.1:
-  version "2.29.3"
-  resolved "https://registry.yarnpkg.com/viem/-/viem-2.29.3.tgz#8cc703758de81b351da8cb84570809103da171cf"
-  integrity sha512-9D/nO+4S3Kk0P8vh6yXUA8OJ0mli9nzoY22qyh8iYHf1Q0GIejUnyq0QGjoDbkTcVzCVD5iA9KBkSxw9Tp3vUg==
-  dependencies:
-    "@noble/curves" "1.8.2"
-    "@noble/hashes" "1.7.2"
-    "@scure/bip32" "1.6.2"
-    "@scure/bip39" "1.5.4"
-    abitype "1.0.8"
-    isows "1.0.6"
-    ox "0.6.9"
-    ws "8.18.1"
-
 viem@^2.24.3:
   version "2.24.3"
   resolved "https://registry.yarnpkg.com/viem/-/viem-2.24.3.tgz#e34f686eed9d19caa2e8a162a29a85bee4efc21e"
@@ -12105,7 +12058,7 @@ ws@8.18.2:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.2.tgz#42738b2be57ced85f46154320aabb51ab003705a"
   integrity sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==
 
-ws@^7.5.1, ws@^7.5.10:
+ws@^7, ws@^7.5.1, ws@^7.5.10:
   version "7.5.10"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,7 +46,7 @@
   resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz#63430d04bd8c5e74f8d7d049338f1cd9d4f02069"
   integrity sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==
 
-"@adraffy/ens-normalize@^1.10.1":
+"@adraffy/ens-normalize@^1.10.1", "@adraffy/ens-normalize@^1.11.0":
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz#42cc67c5baa407ac25059fcd7d405cc5ecdb0c33"
   integrity sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==
@@ -3352,6 +3352,11 @@
   dependencies:
     tslib "2.8.1"
 
+"@noble/ciphers@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@noble/ciphers/-/ciphers-1.3.0.tgz#f64b8ff886c240e644e5573c097f86e5b43676dc"
+  integrity sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==
+
 "@noble/curves@1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.2.0.tgz#92d7e12e4e49b23105a2555c6984d41733d65c35"
@@ -3386,6 +3391,13 @@
   integrity sha512-vnI7V6lFNe0tLAuJMu+2sX+FcL14TaCWy1qiczg1VwRmPrpQCdq5ESXQMqUc2tluRNf6irBXrWbl1mGN8uaU/g==
   dependencies:
     "@noble/hashes" "1.7.2"
+
+"@noble/curves@1.9.2", "@noble/curves@^1.9.1", "@noble/curves@~1.9.0":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.9.2.tgz#73388356ce733922396214a933ff7c95afcef911"
+  integrity sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g==
+  dependencies:
+    "@noble/hashes" "1.8.0"
 
 "@noble/curves@^1.4.2", "@noble/curves@^1.6.0", "@noble/curves@~1.7.0":
   version "1.7.0"
@@ -3431,7 +3443,7 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.7.2.tgz#d53c65a21658fb02f3303e7ee3ba89d6754c64b4"
   integrity sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ==
 
-"@noble/hashes@1.8.0", "@noble/hashes@^1", "@noble/hashes@~1.8.0":
+"@noble/hashes@1.8.0", "@noble/hashes@^1.8.0", "@noble/hashes@~1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
@@ -3610,6 +3622,11 @@
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.4.tgz#002eb571a35d69bdb4c214d0995dff76a8dcd2a9"
   integrity sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==
 
+"@scure/base@~1.2.5":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.6.tgz#ca917184b8231394dd8847509c67a0be522e59f6"
+  integrity sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==
+
 "@scure/bip32@1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.4.0.tgz#4e1f1e196abedcef395b33b9674a042524e20d67"
@@ -3628,7 +3645,7 @@
     "@noble/hashes" "~1.7.1"
     "@scure/base" "~1.2.2"
 
-"@scure/bip32@^1.4.0":
+"@scure/bip32@1.7.0", "@scure/bip32@^1.7.0":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.7.0.tgz#b8683bab172369f988f1589640e53c4606984219"
   integrity sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==
@@ -3662,7 +3679,7 @@
     "@noble/hashes" "~1.7.1"
     "@scure/base" "~1.2.4"
 
-"@scure/bip39@^1.3.0":
+"@scure/bip39@1.6.0", "@scure/bip39@^1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.6.0.tgz#475970ace440d7be87a6086cbee77cb8f1a684f9"
   integrity sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==
@@ -5699,15 +5716,15 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"@zerodev/ecdsa-validator@^5.4.5":
-  version "5.4.5"
-  resolved "https://registry.yarnpkg.com/@zerodev/ecdsa-validator/-/ecdsa-validator-5.4.5.tgz#f70f0efb524bdb132560c083971396fcaf1ea216"
-  integrity sha512-B9QsqqNZBevny+KzTQOiOGlFC1NreU1dlEW2ghZzCpYLVLgpQ7iOpRoOMmFyfsTVJoQQoSNEfgkoE9gzh2V8fw==
+"@zerodev/ecdsa-validator@^5.4.9":
+  version "5.4.9"
+  resolved "https://registry.yarnpkg.com/@zerodev/ecdsa-validator/-/ecdsa-validator-5.4.9.tgz#106226ac90f52f780f146037a4f1e32f6ccbe3a6"
+  integrity sha512-9NVE8/sQIKRo42UOoYKkNdmmHJY8VlT4t+2MHD2ipLg21cpbY9fS17TGZh61+Bl3qlqc8pP23I6f89z9im7kuA==
 
-"@zerodev/sdk@^5.4.28":
-  version "5.4.28"
-  resolved "https://registry.yarnpkg.com/@zerodev/sdk/-/sdk-5.4.28.tgz#94a7cb56dcbc29209b06641abdec48014e749450"
-  integrity sha512-gnD9gEmLUHy3nt8XfRJvGivu17XbwJdLzw8/keidr/stLqYpUJ/cWASrB48YeA1EJk0/Vy3Fd/tULi3sl7JUYA==
+"@zerodev/sdk@^5.4.40":
+  version "5.4.40"
+  resolved "https://registry.yarnpkg.com/@zerodev/sdk/-/sdk-5.4.40.tgz#5943876fe4a03a6bf9aecc2a49bbc4d1ea0be6b2"
+  integrity sha512-G79tZN7s2TWCVNGofqiG8bxd3jnbB0+lW9O7LEHdBPsINuBiKYtUHO1p026KkCtvhHk118TtHYRbb0bOFrvHtQ==
   dependencies:
     semver "^7.6.0"
 
@@ -6626,6 +6643,7 @@ commander@11.1.0:
   integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
 
 commander@4.1.1, commander@^4.0.0:
+commander@4.1.1, commander@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
@@ -7140,6 +7158,14 @@ enumify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmmirror.com/enumify/-/enumify-2.0.0.tgz#7b079efa0ce2a4ebf1a8da24c4544000db41af3e"
   integrity sha512-hpyRdixXrBdr1sZOWH/WKBleMtHWVbM+DyVa0OqKQnKEw6x0TuUNYjcWKlp5/+tdiOsbgYiaZ/pYUeMake4k8A==
+
+env-cmd@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/env-cmd/-/env-cmd-10.1.0.tgz#c7f5d3b550c9519f137fdac4dd8fb6866a8c8c4b"
+  integrity sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==
+  dependencies:
+    commander "^4.0.0"
+    cross-spawn "^7.0.0"
 
 env-cmd@^10.1.0:
   version "10.1.0"
@@ -8490,6 +8516,11 @@ isows@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/isows/-/isows-1.0.6.tgz#0da29d706fa51551c663c627ace42769850f86e7"
   integrity sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==
+
+isows@1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/isows/-/isows-1.0.7.tgz#1c06400b7eed216fbba3bcbd68f12490fc342915"
+  integrity sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.2"
@@ -9923,6 +9954,20 @@ ox@0.6.9:
     abitype "^1.0.6"
     eventemitter3 "5.0.1"
 
+ox@0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/ox/-/ox-0.8.1.tgz#c1328e4c890583b9c19d338126aef4b796d53543"
+  integrity sha512-e+z5epnzV+Zuz91YYujecW8cF01mzmrUtWotJ0oEPym/G82uccs7q0WDHTYL3eiONbTUEvcZrptAKLgTBD3u2A==
+  dependencies:
+    "@adraffy/ens-normalize" "^1.11.0"
+    "@noble/ciphers" "^1.3.0"
+    "@noble/curves" "^1.9.1"
+    "@noble/hashes" "^1.8.0"
+    "@scure/bip32" "^1.7.0"
+    "@scure/bip39" "^1.6.0"
+    abitype "^1.0.8"
+    eventemitter3 "5.0.1"
+
 p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -10053,10 +10098,10 @@ pend@~1.2.0:
   resolved "https://registry.npmmirror.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
 
-permissionless@^0.2.39:
-  version "0.2.39"
-  resolved "https://registry.yarnpkg.com/permissionless/-/permissionless-0.2.39.tgz#f9126df2635b44aa3f48f59c6fab9353bcfbee87"
-  integrity sha512-bw6Q41aj0dhwNhPfojzGk+7UTRIGgnzKbnGRlzwB2xI8SI2/yD7EE/IQWm/NbUWHE0yp9GaNOVcqB5mCBFTDNw==
+permissionless@^0.2.49:
+  version "0.2.49"
+  resolved "https://registry.yarnpkg.com/permissionless/-/permissionless-0.2.49.tgz#57a2ce6d026a093bde03d9425485a2316d335771"
+  integrity sha512-BiMnbCxUDRJ01ppDIrx0S5c7oN9XSz2SaG2F4AIIzqUhEE1tWBJW64Usb+q57cxHjGpGaUX6/3hzmx/H75l3Ww==
 
 picocolors@^1.0.0, picocolors@^1.1.0:
   version "1.1.1"
@@ -11851,6 +11896,20 @@ viem@^2.25.0:
     ox "0.6.9"
     ws "8.18.1"
 
+viem@^2.31.7:
+  version "2.31.7"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.31.7.tgz#1b8afa221a96a98edf9349760c6925f67c123dd6"
+  integrity sha512-mpB8Hp6xK77E/b/yJmpAIQcxcOfpbrwWNItjnXaIA8lxZYt4JS433Pge2gg6Hp3PwyFtaUMh01j5L8EXnLTjQQ==
+  dependencies:
+    "@noble/curves" "1.9.2"
+    "@noble/hashes" "1.8.0"
+    "@scure/bip32" "1.7.0"
+    "@scure/bip39" "1.6.0"
+    abitype "1.0.8"
+    isows "1.0.7"
+    ox "0.8.1"
+    ws "8.18.2"
+
 walker@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.8.tgz#bd498db477afe573dc04185f011d3ab8a8d7653f"
@@ -12041,7 +12100,12 @@ ws@8.18.1, ws@^8.5.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.1.tgz#ea131d3784e1dfdff91adb0a4a116b127515e3cb"
   integrity sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==
 
-ws@^7, ws@^7.5.1, ws@^7.5.10:
+ws@8.18.2:
+  version "8.18.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.2.tgz#42738b2be57ced85f46154320aabb51ab003705a"
+  integrity sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==
+
+ws@^7.5.1, ws@^7.5.10:
   version "7.5.10"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==


### PR DESCRIPTION
- This PR adds support for Viem's fallback transport: https://viem.sh/docs/clients/transports/fallback#fallback-transport
- It is retro compatible with the previous model, i.e., if only one URL is configured it won't use fallback.
- It also updates viem version to take advantage of recent fixes related to websockets (https://github.com/wevm/viem/blob/main/src/CHANGELOG.md#2317)
- Depends on this change on eco-chains: https://github.com/eco/eco-chains/pull/73