### PR TITLE
Parallel execution of fulfillment jobs with chain-aware concurrency

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -25,6 +25,7 @@ import { SolverModule } from '@/solver/solver.module'
 import { PermitProcessingModule } from '@/permit-processing/permit-processing.module'
 import { IntentInitiationModule } from '@/intent-initiation/intent-initiation.module'
 import { SolverRegistrationModule } from '@/solver-registration/solver-registration.module'
+import { IntentFulfillmentModule } from '@/intent-fulfillment/intent-fulfillment.module'
 
 @Module({
   imports: [
@@ -75,6 +76,7 @@ import { SolverRegistrationModule } from '@/solver-registration/solver-registrat
     LiquidityManagerModule,
     WatchModule,
     IntentProcessorModule,
+    IntentFulfillmentModule,
     ...getPino(),
   ],
   controllers: [],

--- a/src/bullmq/processors/solve-intent.processor.ts
+++ b/src/bullmq/processors/solve-intent.processor.ts
@@ -67,9 +67,6 @@ export class SolveIntentProcessor extends WorkerHost {
         case QUEUES.SOURCE_INTENT.jobs.feasable_intent:
           result = await this.feasableIntentService.feasableIntent(job.data as Hex)
           break
-        case QUEUES.SOURCE_INTENT.jobs.fulfill_intent:
-          result = await this.fulfillIntentService.fulfill(job.data as Hex)
-          break
         default:
           throw new Error(`Unknown job type: ${job.name}`)
       }

--- a/src/common/bullmq/base-job.ts
+++ b/src/common/bullmq/base-job.ts
@@ -1,7 +1,7 @@
 /* eslint @typescript-eslint/no-unused-vars: 0 */
 import { Job as BullMQJob } from 'bullmq'
 
-export abstract class BaseJobManager<Job extends BullMQJob> {
+export abstract class BaseJobManager<Job extends BullMQJob, Processor = unknown> {
   /**
    * Checks if the given job is of the specific type.
    * @param job - The job to check.
@@ -14,14 +14,14 @@ export abstract class BaseJobManager<Job extends BullMQJob> {
    * @param job - The job to process.
    * @param processor - The processor handling the job.
    */
-  abstract process(job: Job, processor: unknown): Promise<Job['returnvalue']>
+  abstract process(job: Job, processor: Processor): Promise<Job['returnvalue']>
 
   /**
    * Hook triggered when a job is completed.
    * @param job - The job to process.
    * @param processor - The processor handling the job.
    */
-  onComplete(job: Job, processor: unknown): void {
+  onComplete(job: Job, processor: Processor): void {
     // Placeholder method implementation
   }
 
@@ -30,7 +30,7 @@ export abstract class BaseJobManager<Job extends BullMQJob> {
    * @param job - The job to process.
    * @param processor - The processor handling the job.
    */
-  onFailed(job: Job, processor: unknown, error: unknown): void {
+  onFailed(job: Job, processor: Processor, error: unknown): void {
     // Placeholder method implementation
   }
 }

--- a/src/common/redis/constants.ts
+++ b/src/common/redis/constants.ts
@@ -6,7 +6,6 @@ export const QUEUES: Record<any, QueueInterface> = {
       create_intent: 'create_intent',
       validate_intent: 'validate_intent',
       feasable_intent: 'feasable_intent',
-      fulfill_intent: 'fulfill_intent',
       retry_intent: 'retry_intent',
     },
   },

--- a/src/intent-fulfillment/intent-fulfillment.module.ts
+++ b/src/intent-fulfillment/intent-fulfillment.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common'
+import { IntentFulfillmentProcessor } from '@/intent-fulfillment/processors/intent-fulfillment.processor'
+import { IntentFulfillmentQueue } from '@/intent-fulfillment/queues/intent-fulfillment.queue'
+import { IntentModule } from '@/intent/intent.module'
+
+@Module({
+  imports: [IntentFulfillmentQueue.init(), IntentModule],
+  providers: [IntentFulfillmentProcessor],
+  exports: [IntentFulfillmentQueue.init()],
+})
+export class IntentFulfillmentModule {}

--- a/src/intent-fulfillment/intent-fulfillment.module.ts
+++ b/src/intent-fulfillment/intent-fulfillment.module.ts
@@ -1,10 +1,10 @@
-import { Module } from '@nestjs/common'
+import { forwardRef, Module } from '@nestjs/common'
 import { IntentFulfillmentProcessor } from '@/intent-fulfillment/processors/intent-fulfillment.processor'
 import { IntentFulfillmentQueue } from '@/intent-fulfillment/queues/intent-fulfillment.queue'
 import { IntentModule } from '@/intent/intent.module'
 
 @Module({
-  imports: [IntentFulfillmentQueue.init(), IntentModule],
+  imports: [IntentFulfillmentQueue.init(), forwardRef(() => IntentModule)],
   providers: [IntentFulfillmentProcessor],
   exports: [IntentFulfillmentQueue.init()],
 })

--- a/src/intent-fulfillment/intent-fulfillment.module.ts
+++ b/src/intent-fulfillment/intent-fulfillment.module.ts
@@ -5,7 +5,7 @@ import { IntentModule } from '@/intent/intent.module'
 
 @Module({
   imports: [IntentFulfillmentQueue.init(), forwardRef(() => IntentModule)],
-  providers: [IntentFulfillmentProcessor],
-  exports: [IntentFulfillmentQueue.init()],
+  providers: [IntentFulfillmentProcessor, IntentFulfillmentQueue],
+  exports: [IntentFulfillmentQueue],
 })
 export class IntentFulfillmentModule {}

--- a/src/intent-fulfillment/jobs/fulfill-intent.job.ts
+++ b/src/intent-fulfillment/jobs/fulfill-intent.job.ts
@@ -1,0 +1,64 @@
+import { JobsOptions, Job } from 'bullmq'
+import { Hex } from 'viem'
+import { BaseJobManager } from '@/common/bullmq/base-job'
+import { IntentFulfillmentJobName } from '@/intent-fulfillment/queues/intent-fulfillment.queue'
+import { serialize, Serialize, deserialize } from '@/common/utils/serialize'
+import { getIntentJobId } from '@/common/utils/strings'
+import { EcoLogMessage } from '@/common/logging/eco-log-message'
+
+export type FulfillIntentJobData = {
+  intentHash: Hex
+  chainId: number
+}
+
+export type FulfillIntentJob = Job<
+  Serialize<FulfillIntentJobData>,
+  unknown,
+  IntentFulfillmentJobName.FULFILL_INTENT
+>
+
+export abstract class IntentFulfillmentJobManager extends BaseJobManager<FulfillIntentJob> {}
+
+export class FulfillIntentJobManager extends IntentFulfillmentJobManager {
+  static createJob(jobData: FulfillIntentJobData): {
+    name: FulfillIntentJob['name']
+    data: FulfillIntentJob['data']
+    opts?: JobsOptions
+  } {
+    const jobId = getIntentJobId('fulfill', jobData.intentHash, jobData.chainId)
+    return {
+      name: IntentFulfillmentJobName.FULFILL_INTENT,
+      data: serialize(jobData),
+      opts: {
+        jobId,
+        attempts: 3,
+        backoff: {
+          type: 'exponential',
+          delay: 1000,
+        },
+      },
+    }
+  }
+
+  is(job: FulfillIntentJob): job is FulfillIntentJob {
+    return job.name === IntentFulfillmentJobName.FULFILL_INTENT
+  }
+
+  async process(job: FulfillIntentJob, processor: any): Promise<void> {
+    if (this.is(job)) {
+      return processor.fulfillIntentService.fulfill(deserialize(job.data).intentHash)
+    }
+  }
+
+  onFailed(job: FulfillIntentJob, processor: any, error: Error) {
+    processor.logger.error(
+      EcoLogMessage.fromDefault({
+        message: `${FulfillIntentJobManager.name}: Failed`,
+        properties: {
+          job: { id: job.id, data: deserialize(job.data) },
+          error: error.message,
+        },
+      }),
+    )
+  }
+}

--- a/src/intent-fulfillment/processors/intent-fulfillment.processor.ts
+++ b/src/intent-fulfillment/processors/intent-fulfillment.processor.ts
@@ -11,8 +11,9 @@ import {
 } from '@/intent-fulfillment/jobs/fulfill-intent.job'
 import { FulfillIntentService } from '@/intent/fulfill-intent.service'
 
+const CONCURRENCY = 10
 @Injectable()
-@Processor(IntentFulfillmentQueue.queueName, { concurrency: 10 })
+@Processor(IntentFulfillmentQueue.queueName, { concurrency: CONCURRENCY })
 export class IntentFulfillmentProcessor extends GroupedJobsProcessor<FulfillIntentJob> {
   constructor(
     @InjectQueue(IntentFulfillmentQueue.queueName)

--- a/src/intent-fulfillment/processors/intent-fulfillment.processor.ts
+++ b/src/intent-fulfillment/processors/intent-fulfillment.processor.ts
@@ -1,0 +1,24 @@
+import { InjectQueue, Processor } from '@nestjs/bullmq'
+import { Injectable } from '@nestjs/common'
+import {
+  IntentFulfillmentQueue,
+  IntentFulfillmentQueueType,
+} from '@/intent-fulfillment/queues/intent-fulfillment.queue'
+import { GroupedJobsProcessor } from '@/common/bullmq/grouped-jobs.processor'
+import {
+  FulfillIntentJob,
+  FulfillIntentJobManager,
+} from '@/intent-fulfillment/jobs/fulfill-intent.job'
+import { FulfillIntentService } from '@/intent/fulfill-intent.service'
+
+@Injectable()
+@Processor(IntentFulfillmentQueue.queueName, { concurrency: 10 })
+export class IntentFulfillmentProcessor extends GroupedJobsProcessor<FulfillIntentJob> {
+  constructor(
+    @InjectQueue(IntentFulfillmentQueue.queueName)
+    public readonly queue: IntentFulfillmentQueueType,
+    public readonly fulfillIntentService: FulfillIntentService,
+  ) {
+    super('chainId', IntentFulfillmentProcessor.name, [new FulfillIntentJobManager()])
+  }
+}

--- a/src/intent-fulfillment/queues/intent-fulfillment.queue.ts
+++ b/src/intent-fulfillment/queues/intent-fulfillment.queue.ts
@@ -1,11 +1,15 @@
 import { Queue } from 'bullmq'
 import { initBullMQ } from '@/bullmq/bullmq.helper'
+import { Hex } from 'viem/_types/types/misc'
 
 export enum IntentFulfillmentJobName {
   FULFILL_INTENT = 'FULFILL_INTENT',
 }
 
-export type IntentFulfillmentQueueDataType = any
+export type IntentFulfillmentQueueDataType = {
+  intentHash: Hex
+  chainId: number
+}
 
 export type IntentFulfillmentQueueType = Queue<
   IntentFulfillmentQueueDataType,

--- a/src/intent-fulfillment/queues/intent-fulfillment.queue.ts
+++ b/src/intent-fulfillment/queues/intent-fulfillment.queue.ts
@@ -1,0 +1,41 @@
+import { Queue } from 'bullmq'
+import { initBullMQ } from '@/bullmq/bullmq.helper'
+
+export enum IntentFulfillmentJobName {
+  FULFILL_INTENT = 'FULFILL_INTENT',
+}
+
+export type IntentFulfillmentQueueDataType = any
+
+export type IntentFulfillmentQueueType = Queue<
+  IntentFulfillmentQueueDataType,
+  unknown,
+  IntentFulfillmentJobName
+>
+
+export class IntentFulfillmentQueue {
+  public static readonly prefix = '{intent-fulfillment}'
+  public static readonly queueName = 'IntentFulfillment'
+
+  constructor(private readonly queue: IntentFulfillmentQueueType) {}
+
+  get name() {
+    return this.queue.name
+  }
+
+  static init() {
+    return initBullMQ(
+      { queue: this.queueName, prefix: IntentFulfillmentQueue.prefix },
+      {
+        defaultJobOptions: {
+          removeOnFail: true,
+          removeOnComplete: true,
+        },
+      },
+    )
+  }
+
+  addFulfillIntentJob(jobData: any) {
+    return this.queue.add(IntentFulfillmentJobName.FULFILL_INTENT, jobData)
+  }
+}

--- a/src/intent-fulfillment/queues/intent-fulfillment.queue.ts
+++ b/src/intent-fulfillment/queues/intent-fulfillment.queue.ts
@@ -1,6 +1,8 @@
 import { Queue } from 'bullmq'
 import { initBullMQ } from '@/bullmq/bullmq.helper'
 import { Hex } from 'viem/_types/types/misc'
+import { Injectable } from '@nestjs/common'
+import { InjectQueue } from '@nestjs/bullmq'
 
 export enum IntentFulfillmentJobName {
   FULFILL_INTENT = 'FULFILL_INTENT',
@@ -16,12 +18,15 @@ export type IntentFulfillmentQueueType = Queue<
   unknown,
   IntentFulfillmentJobName
 >
-
+@Injectable()
 export class IntentFulfillmentQueue {
   public static readonly prefix = '{intent-fulfillment}'
   public static readonly queueName = 'IntentFulfillment'
 
-  constructor(private readonly queue: IntentFulfillmentQueueType) {}
+  constructor(
+    @InjectQueue(IntentFulfillmentQueue.queueName)
+    private readonly queue: IntentFulfillmentQueueType,
+  ) {}
 
   get name() {
     return this.queue.name

--- a/src/intent-fulfillment/tests/fulfill-intent.job.spec.ts
+++ b/src/intent-fulfillment/tests/fulfill-intent.job.spec.ts
@@ -1,0 +1,95 @@
+import { FulfillIntentJob, FulfillIntentJobManager } from '../jobs/fulfill-intent.job'
+import { IntentFulfillmentJobName } from '../queues/intent-fulfillment.queue'
+import { deserialize, serialize } from '@/common/utils/serialize'
+import { Hex } from 'viem'
+import * as stringUtils from '@/common/utils/strings'
+import { createMock } from '@golevelup/ts-jest'
+
+describe('FulfillIntentJobManager', () => {
+  describe('createJob', () => {
+    it('should create a job with the correct parameters', () => {
+      const jobData = {
+        intentHash: '0x123' as Hex,
+        chainId: 1,
+      }
+
+      const jobId = 'fulfill-0x123-1'
+      jest.spyOn(stringUtils, 'getIntentJobId').mockReturnValue(jobId)
+
+      const job = FulfillIntentJobManager.createJob(jobData)
+
+      expect(stringUtils.getIntentJobId).toHaveBeenCalledWith(
+        'fulfill',
+        jobData.intentHash,
+        jobData.chainId,
+      )
+      expect(job.name).toBe(IntentFulfillmentJobName.FULFILL_INTENT)
+      expect(job.data).toEqual(serialize(jobData))
+      expect(job.opts).toEqual({
+        jobId,
+        attempts: 3,
+        backoff: {
+          type: 'exponential',
+          delay: 1000,
+        },
+      })
+    })
+  })
+
+  describe('process', () => {
+    it('should call the fulfill intent service with the correct intent hash', async () => {
+      const jobData = {
+        intentHash: '0x456' as Hex,
+        chainId: 1,
+      }
+      const job = {
+        name: IntentFulfillmentJobName.FULFILL_INTENT,
+        data: serialize(jobData),
+      } as FulfillIntentJob
+
+      const mockFulfillIntentService = {
+        fulfill: jest.fn(),
+      }
+      const mockProcessor = {
+        fulfillIntentService: mockFulfillIntentService,
+      }
+
+      const manager = new FulfillIntentJobManager()
+      await manager.process(job, mockProcessor as any)
+
+      expect(mockFulfillIntentService.fulfill).toHaveBeenCalledWith(jobData.intentHash)
+    })
+  })
+
+  describe('onFailed', () => {
+    it('should log an error message with job details', () => {
+      const jobData = {
+        intentHash: '0x789' as Hex,
+        chainId: 1,
+      }
+      const job = {
+        name: IntentFulfillmentJobName.FULFILL_INTENT,
+        id: 'job-123',
+        data: serialize(jobData),
+      } as FulfillIntentJob
+      const error = new Error('Something went wrong')
+      const mockLogger = {
+        error: jest.fn(),
+      }
+      const mockProcessor = {
+        logger: mockLogger,
+      }
+
+      const manager = new FulfillIntentJobManager()
+      manager.onFailed(job, mockProcessor as any, error)
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          msg: 'FulfillIntentJobManager: Failed',
+          job: { id: 'job-123', data: jobData },
+          error: 'Something went wrong',
+        }),
+      )
+    })
+  })
+})

--- a/src/intent-fulfillment/tests/fulfill-intent.job.spec.ts
+++ b/src/intent-fulfillment/tests/fulfill-intent.job.spec.ts
@@ -52,6 +52,12 @@ describe('FulfillIntentJobManager', () => {
       }
       const mockProcessor = {
         fulfillIntentService: mockFulfillIntentService,
+        logger: {
+          debug: jest.fn(),
+          log: jest.fn(),
+          error: jest.fn(),
+          warn: jest.fn(),
+        },
       }
 
       const manager = new FulfillIntentJobManager()

--- a/src/intent-fulfillment/tests/intent-fulfillment.processor.spec.ts
+++ b/src/intent-fulfillment/tests/intent-fulfillment.processor.spec.ts
@@ -1,0 +1,68 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { IntentFulfillmentProcessor } from '../processors/intent-fulfillment.processor'
+import { getQueueToken } from '@nestjs/bullmq'
+import {
+  IntentFulfillmentQueue,
+  IntentFulfillmentJobName,
+} from '../queues/intent-fulfillment.queue'
+import { FulfillIntentService } from '@/intent/fulfill-intent.service'
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+import { FulfillIntentJob } from '../jobs/fulfill-intent.job'
+import { serialize } from '@/common/utils/serialize'
+import { Hex } from 'viem'
+
+describe('IntentFulfillmentProcessor', () => {
+  let processor: IntentFulfillmentProcessor
+  let fulfillIntentService: DeepMocked<FulfillIntentService>
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        IntentFulfillmentProcessor,
+        {
+          provide: getQueueToken(IntentFulfillmentQueue.queueName),
+          useValue: createMock<IntentFulfillmentQueue>(),
+        },
+        {
+          provide: FulfillIntentService,
+          useValue: createMock<FulfillIntentService>(),
+        },
+      ],
+    }).compile()
+
+    processor = module.get<IntentFulfillmentProcessor>(IntentFulfillmentProcessor)
+    fulfillIntentService = module.get(FulfillIntentService)
+  })
+
+  it('should be defined', () => {
+    expect(processor).toBeDefined()
+  })
+
+  it('should delegate job processing to FulfillIntentService with correct params', async () => {
+    const intentHash = '0x12345' as Hex
+    const jobData = { intentHash, chainId: 1 }
+    const mockJob = {
+      name: IntentFulfillmentJobName.FULFILL_INTENT,
+      data: serialize(jobData),
+    } as FulfillIntentJob
+
+    // Directly test the job manager's process method, which is what the processor calls
+    const manager = processor['jobManagers'][0]
+    await manager.process(mockJob, processor)
+
+    expect(fulfillIntentService.fulfill).toHaveBeenCalledTimes(1)
+    expect(fulfillIntentService.fulfill).toHaveBeenCalledWith(intentHash)
+  })
+
+  it('should not process a job with an unknown name', async () => {
+    const mockJob = {
+      name: 'UNKNOWN_JOB',
+      data: serialize({}),
+    } as any
+
+    const manager = processor['jobManagers'][0]
+    await manager.process(mockJob, processor)
+
+    expect(fulfillIntentService.fulfill).not.toHaveBeenCalled()
+  })
+})

--- a/src/intent/feasable-intent.service.ts
+++ b/src/intent/feasable-intent.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, Logger } from '@nestjs/common'
-import { InjectQueue } from '@nestjs/bullmq'
 import { UtilsIntentService } from './utils-intent.service'
 import { EcoLogMessage } from '../common/logging/eco-log-message'
 import { getIntentJobId } from '../common/utils/strings'
@@ -8,10 +7,7 @@ import { QuoteIntentModel } from '@/quote/schemas/quote-intent.schema'
 import { FeeService } from '@/fee/fee.service'
 import { EcoAnalyticsService } from '@/analytics'
 import { ERROR_EVENTS } from '@/analytics/events.constants'
-import {
-  IntentFulfillmentQueue,
-  IntentFulfillmentQueueType,
-} from '@/intent-fulfillment/queues/intent-fulfillment.queue'
+import { IntentFulfillmentQueue } from '@/intent-fulfillment/queues/intent-fulfillment.queue'
 
 /**
  * Service class for getting configs for the app
@@ -19,16 +15,12 @@ import {
 @Injectable()
 export class FeasableIntentService {
   private logger = new Logger(FeasableIntentService.name)
-  private readonly intentFulfillmentQueue: IntentFulfillmentQueue
   constructor(
-    @InjectQueue(IntentFulfillmentQueue.queueName)
-    intentFulfillmentQueue: IntentFulfillmentQueueType,
+    private readonly intentFulfillmentQueue: IntentFulfillmentQueue,
     private readonly feeService: FeeService,
     private readonly utilsIntentService: UtilsIntentService,
     private readonly ecoAnalytics: EcoAnalyticsService,
-  ) {
-    this.intentFulfillmentQueue = new IntentFulfillmentQueue(intentFulfillmentQueue)
-  }
+  ) {}
 
   async feasableQuote(quoteIntent: QuoteIntentModel) {
     try {

--- a/src/intent/feasable-intent.service.ts
+++ b/src/intent/feasable-intent.service.ts
@@ -1,6 +1,4 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common'
-import { EcoConfigService } from '../eco-configs/eco-config.service'
-import { JobsOptions } from 'bullmq'
+import { Injectable, Logger } from '@nestjs/common'
 import { InjectQueue } from '@nestjs/bullmq'
 import { UtilsIntentService } from './utils-intent.service'
 import { EcoLogMessage } from '../common/logging/eco-log-message'
@@ -19,24 +17,19 @@ import {
  * Service class for getting configs for the app
  */
 @Injectable()
-export class FeasableIntentService implements OnModuleInit {
+export class FeasableIntentService {
   private logger = new Logger(FeasableIntentService.name)
-  private intentJobConfig: JobsOptions
   private readonly intentFulfillmentQueue: IntentFulfillmentQueue
   constructor(
     @InjectQueue(IntentFulfillmentQueue.queueName)
     intentFulfillmentQueue: IntentFulfillmentQueueType,
     private readonly feeService: FeeService,
     private readonly utilsIntentService: UtilsIntentService,
-    private readonly ecoConfigService: EcoConfigService,
     private readonly ecoAnalytics: EcoAnalyticsService,
   ) {
     this.intentFulfillmentQueue = new IntentFulfillmentQueue(intentFulfillmentQueue)
   }
 
-  async onModuleInit() {
-    this.intentJobConfig = this.ecoConfigService.getRedis().jobs.intentJobConfig
-  }
   async feasableQuote(quoteIntent: QuoteIntentModel) {
     try {
       this.logger.debug(

--- a/src/intent/feasable-intent.service.ts
+++ b/src/intent/feasable-intent.service.ts
@@ -1,8 +1,7 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common'
 import { EcoConfigService } from '../eco-configs/eco-config.service'
-import { JobsOptions, Queue } from 'bullmq'
+import { JobsOptions } from 'bullmq'
 import { InjectQueue } from '@nestjs/bullmq'
-import { QUEUES } from '../common/redis/constants'
 import { UtilsIntentService } from './utils-intent.service'
 import { EcoLogMessage } from '../common/logging/eco-log-message'
 import { getIntentJobId } from '../common/utils/strings'
@@ -11,6 +10,10 @@ import { QuoteIntentModel } from '@/quote/schemas/quote-intent.schema'
 import { FeeService } from '@/fee/fee.service'
 import { EcoAnalyticsService } from '@/analytics'
 import { ERROR_EVENTS } from '@/analytics/events.constants'
+import {
+  IntentFulfillmentQueue,
+  IntentFulfillmentQueueType,
+} from '@/intent-fulfillment/queues/intent-fulfillment.queue'
 
 /**
  * Service class for getting configs for the app
@@ -19,13 +22,17 @@ import { ERROR_EVENTS } from '@/analytics/events.constants'
 export class FeasableIntentService implements OnModuleInit {
   private logger = new Logger(FeasableIntentService.name)
   private intentJobConfig: JobsOptions
+  private readonly intentFulfillmentQueue: IntentFulfillmentQueue
   constructor(
-    @InjectQueue(QUEUES.SOURCE_INTENT.queue) private readonly intentQueue: Queue,
+    @InjectQueue(IntentFulfillmentQueue.queueName)
+    intentFulfillmentQueue: IntentFulfillmentQueueType,
     private readonly feeService: FeeService,
     private readonly utilsIntentService: UtilsIntentService,
     private readonly ecoConfigService: EcoConfigService,
     private readonly ecoAnalytics: EcoAnalyticsService,
-  ) {}
+  ) {
+    this.intentFulfillmentQueue = new IntentFulfillmentQueue(intentFulfillmentQueue)
+  }
 
   async onModuleInit() {
     this.intentJobConfig = this.ecoConfigService.getRedis().jobs.intentJobConfig
@@ -95,9 +102,9 @@ export class FeasableIntentService implements OnModuleInit {
     )
     if (!error) {
       //add to processing queue
-      await this.intentQueue.add(QUEUES.SOURCE_INTENT.jobs.fulfill_intent, intentHash, {
-        jobId,
-        ...this.intentJobConfig,
+      await this.intentFulfillmentQueue.addFulfillIntentJob({
+        intentHash,
+        chainId: Number(model.intent.route.destination),
       })
 
       // Track feasible intent queued for fulfillment

--- a/src/intent/intent.module.ts
+++ b/src/intent/intent.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common'
+import { forwardRef, Module } from '@nestjs/common'
 import { initBullMQ } from '../bullmq/bullmq.helper'
 import { QUEUES } from '../common/redis/constants'
 import { IntentSourceModel, IntentSourceSchema } from './schemas/intent-source.schema'
@@ -17,6 +17,7 @@ import { ValidationService } from '@/intent/validation.sevice'
 import { FeeModule } from '@/fee/fee.module'
 import { WalletFulfillService } from '@/intent/wallet-fulfill.service'
 import { CrowdLiquidityService } from '@/intent/crowd-liquidity.service'
+import { IntentFulfillmentModule } from '@/intent-fulfillment/intent-fulfillment.module'
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { CrowdLiquidityService } from '@/intent/crowd-liquidity.service'
     SolverModule,
     TransactionModule,
     initBullMQ(QUEUES.SOURCE_INTENT),
+    forwardRef(() => IntentFulfillmentModule),
   ],
   providers: [
     CreateIntentService,

--- a/src/intent/tests/feasable-intent.service.spec.ts
+++ b/src/intent/tests/feasable-intent.service.spec.ts
@@ -74,17 +74,6 @@ describe('FeasableIntentService', () => {
     mockLogLog.mockClear()
   })
 
-  describe('onModuleInit', () => {
-    it('should set the intentJobConfig', async () => {
-      const mockConfig = { foo: 'bar' }
-      jest
-        .spyOn(ecoConfigService, 'getRedis')
-        .mockReturnValue({ jobs: { intentJobConfig: mockConfig } } as any)
-      await feasableIntentService.onModuleInit()
-      expect(feasableIntentService['intentJobConfig']).toEqual(mockConfig)
-    })
-  })
-
   describe('on feasableIntent', () => {
     it('should error out if processing intent data fails', async () => {
       jest.spyOn(utilsIntentService, 'getIntentProcessData').mockResolvedValue(undefined)

--- a/src/intent/tests/feasable-intent.service.spec.ts
+++ b/src/intent/tests/feasable-intent.service.spec.ts
@@ -1,153 +1,90 @@
-import { createMock, DeepMocked } from '@golevelup/ts-jest'
-import { EcoConfigService } from '../../eco-configs/eco-config.service'
 import { Test, TestingModule } from '@nestjs/testing'
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
 import { getModelToken } from '@nestjs/mongoose'
-import { IntentSourceModel } from '../schemas/intent-source.schema'
 import { Model } from 'mongoose'
-import { UtilsIntentService } from '../utils-intent.service'
-import { BullModule, getQueueToken } from '@nestjs/bullmq'
-import { Queue } from 'bullmq'
-import { FeasableIntentService } from '../feasable-intent.service'
 import { Hex } from 'viem'
+
+import { FeasableIntentService } from '@/intent/feasable-intent.service'
+import { IntentSourceModel } from '@/intent/schemas/intent-source.schema'
 import { FeeService } from '@/fee/fee.service'
-import { QuoteError } from '@/quote/errors'
+import { UtilsIntentService } from '@/intent/utils-intent.service'
+import { EcoConfigService } from '@/eco-configs/eco-config.service'
 import { EcoAnalyticsService } from '@/analytics'
 import { IntentFulfillmentQueue } from '@/intent-fulfillment/queues/intent-fulfillment.queue'
+import { QuoteError } from '@/quote/errors'
+
+// Minimal re-mock of queue wrapper
+const mockQueue = () => createMock<IntentFulfillmentQueue>({ addFulfillIntentJob: jest.fn() })
 
 describe('FeasableIntentService', () => {
-  let feasableIntentService: FeasableIntentService
+  let service: FeasableIntentService
   let feeService: DeepMocked<FeeService>
   let utilsIntentService: DeepMocked<UtilsIntentService>
-  let ecoConfigService: DeepMocked<EcoConfigService>
-  let queue: DeepMocked<Queue>
-  const mockLogDebug = jest.fn()
-  const mockLogLog = jest.fn()
-  const mockLogError = jest.fn()
-  const address1 = '0x1111111111111111111111111111111111111111'
-  const address2 = '0x2222222222222222222222222222222222222222'
+  let fulfillmentQueue: DeepMocked<IntentFulfillmentQueue>
+
+  const intentHash = '0x123' as Hex
+
   beforeEach(async () => {
-    const chainMod: TestingModule = await Test.createTestingModule({
+    fulfillmentQueue = mockQueue()
+
+    const module: TestingModule = await Test.createTestingModule({
       providers: [
         FeasableIntentService,
         { provide: FeeService, useValue: createMock<FeeService>() },
         { provide: UtilsIntentService, useValue: createMock<UtilsIntentService>() },
         { provide: EcoConfigService, useValue: createMock<EcoConfigService>() },
         { provide: EcoAnalyticsService, useValue: createMock<EcoAnalyticsService>() },
-        {
-          provide: getModelToken(IntentSourceModel.name),
-          useValue: createMock<Model<IntentSourceModel>>(),
-        },
+        { provide: getModelToken(IntentSourceModel.name), useValue: createMock<Model<any>>() },
+        { provide: IntentFulfillmentQueue, useValue: fulfillmentQueue },
       ],
-      imports: [
-        BullModule.registerQueue({
-          name: IntentFulfillmentQueue.queueName,
-        }),
-      ],
-    })
-      .overrideProvider(getQueueToken(IntentFulfillmentQueue.queueName))
-      .useValue(createMock<Queue>())
-      .compile()
+    }).compile()
 
-    feasableIntentService = chainMod.get(FeasableIntentService)
-    feeService = chainMod.get(FeeService)
-    utilsIntentService = chainMod.get(UtilsIntentService)
-    ecoConfigService = chainMod.get(EcoConfigService)
-    queue = chainMod.get(getQueueToken(IntentFulfillmentQueue.queueName))
-
-    feasableIntentService['logger'].debug = mockLogDebug
-    feasableIntentService['logger'].log = mockLogLog
-    feasableIntentService['logger'].error = mockLogError
+    service = module.get(FeasableIntentService)
+    feeService = module.get(FeeService)
+    utilsIntentService = module.get(UtilsIntentService)
   })
 
-  const mockData = {
-    model: {
-      intent: { logIndex: 1, hash: '0x123' as Hex, route: { destination: 1n } },
-    },
-    solver: {},
-  }
-  const intentHash = mockData.model.intent.hash
-  const jobId = `feasable-${intentHash}-${mockData.model.intent.logIndex}`
-  afterEach(async () => {
-    // restore the spy created with spyOn
-    jest.restoreAllMocks()
-    mockLogDebug.mockClear()
-    mockLogLog.mockClear()
+  it('should be defined', () => {
+    expect(service).toBeDefined()
   })
 
-  describe('on feasableIntent', () => {
-    it('should error out if processing intent data fails', async () => {
-      jest.spyOn(utilsIntentService, 'getIntentProcessData').mockResolvedValue(undefined)
-      await expect(feasableIntentService.feasableIntent(intentHash)).resolves.not.toThrow()
+  it('queues intent when feasible', async () => {
+    const mockModel: any = {
+      intent: { logIndex: 1, route: { destination: 2n }, hash: intentHash },
+    }
+    jest
+      .spyOn(utilsIntentService, 'getIntentProcessData')
+      .mockResolvedValue({ model: mockModel, solver: {} } as any)
+    jest.spyOn(feeService, 'isRouteFeasible').mockResolvedValue({} as any)
 
-      const error = new Error('noo')
-      jest
-        .spyOn(utilsIntentService, 'getIntentProcessData')
-        .mockResolvedValue({ err: error } as any)
-      await expect(feasableIntentService.feasableIntent(intentHash)).rejects.toThrow(error)
+    await service.feasableIntent(intentHash)
+
+    expect(fulfillmentQueue.addFulfillIntentJob).toHaveBeenCalledWith({
+      intentHash,
+      chainId: 2,
     })
+  })
 
-    it('should fail if intent has more than 1 target call', async () => {
-      const mockModel = {
-        intent: {
-          route: {
-            calls: [
-              { data: '0x', target: address1 },
-              { data: '0x', target: address2 },
-            ],
-          },
-          logIndex: 1,
-        },
-      }
-      const errData = { solver: mockData.solver, model: mockModel } as any
-      jest.spyOn(utilsIntentService, 'getIntentProcessData').mockResolvedValue(errData)
-      jest.spyOn(feeService, 'isRouteFeasible').mockResolvedValue({
-        error: QuoteError.MultiFulfillRoute(),
-      } as any)
-      await feasableIntentService.feasableIntent(intentHash)
-      expect(utilsIntentService.updateInfeasableIntentModel).toHaveBeenCalledWith(
-        errData.model,
-        QuoteError.MultiFulfillRoute(),
-      )
-      expect(mockLogDebug).toHaveBeenCalledTimes(2)
-      expect(mockLogDebug).toHaveBeenNthCalledWith(2, {
-        msg: `FeasableIntent intent ${intentHash}`,
-        feasable: false,
-      })
-      expect(queue.add).not.toHaveBeenCalled()
-    })
+  it('updates model when infeasible', async () => {
+    const mockModel: any = { intent: { route: { destination: 1n }, logIndex: 1 } }
+    jest
+      .spyOn(utilsIntentService, 'getIntentProcessData')
+      .mockResolvedValue({ model: mockModel, solver: {} } as any)
+    jest
+      .spyOn(feeService, 'isRouteFeasible')
+      .mockResolvedValue({ error: QuoteError.MultiFulfillRoute() } as any)
 
-    it('should update the db intent model if the intent is not feasable', async () => {
-      jest.spyOn(utilsIntentService, 'getIntentProcessData').mockResolvedValue(mockData as any)
-      jest
-        .spyOn(feeService, 'isRouteFeasible')
-        .mockResolvedValue({ error: QuoteError.MultiFulfillRoute() })
+    await service.feasableIntent(intentHash)
+    expect(fulfillmentQueue.addFulfillIntentJob).not.toHaveBeenCalled()
+  })
 
-      await feasableIntentService.feasableIntent(intentHash)
+  it('ignores when model/solver missing and propagates error', async () => {
+    jest.spyOn(utilsIntentService, 'getIntentProcessData').mockResolvedValue(undefined as any)
+    await service.feasableIntent(intentHash)
+    expect(fulfillmentQueue.addFulfillIntentJob).not.toHaveBeenCalled()
 
-      expect(utilsIntentService.updateInfeasableIntentModel).toHaveBeenCalledWith(
-        mockData.model,
-        QuoteError.MultiFulfillRoute(),
-      )
-    })
-
-    it('should add the intent when its feasable to the queue to be processed', async () => {
-      jest.spyOn(utilsIntentService, 'getIntentProcessData').mockResolvedValue(mockData as any)
-      jest.spyOn(feeService, 'isRouteFeasible').mockResolvedValue({ calls: [] } as any)
-      const mockAdd = jest.fn()
-      feasableIntentService['intentFulfillmentQueue'].addFulfillIntentJob = mockAdd
-
-      await feasableIntentService.feasableIntent(intentHash)
-
-      expect(mockLogDebug).toHaveBeenCalledTimes(2)
-      expect(mockLogDebug).toHaveBeenNthCalledWith(2, {
-        msg: `FeasableIntent intent ${intentHash}`,
-        feasable: true,
-        jobId,
-      })
-      expect(mockAdd).toHaveBeenCalledWith({
-        chainId: Number(mockData.model.intent.route.destination),
-        intentHash: mockData.model.intent.hash,
-      })
-    })
+    const e = new Error('db')
+    jest.spyOn(utilsIntentService, 'getIntentProcessData').mockResolvedValue({ err: e } as any)
+    await expect(service.feasableIntent(intentHash)).rejects.toThrow(e)
   })
 })


### PR DESCRIPTION
This pull request introduces parallel execution for intent fulfillment jobs to enhance system throughput and reduce latency, as outlined in ticket: https://eco.atlassian.net/browse/ED-5665

To achieve this safely and in a maintainable way, a new, dedicated IntentFulfillmentModule was created, isolating the new concurrency logic from the existing intent processing pipeline. 

This new module features its own BullMQ queue and a processor that extends GroupedJobsProcessor, using the destination chainId as the grouping key. This ensures that fulfillment jobs for different chains can run in parallel, while jobs for the same chain are executed sequentially to prevent race conditions. 

The FeasableIntentService was updated to enqueue jobs to this new system, and the old fulfillment logic was cleanly removed. 