### PR TITLE
Fix warp routes

### DIFF
--- a/src/liquidity-manager/services/liquidity-providers/Hyperlane/warp-route-provider.service.ts
+++ b/src/liquidity-manager/services/liquidity-providers/Hyperlane/warp-route-provider.service.ts
@@ -547,21 +547,21 @@ export class WarpRouteProviderService implements IRebalanceProvider<'WarpRoute'>
           chainId: candidateToken.chainId,
           token: candidateToken.token,
         })
-        const [tokenData] = await this.balanceService.getAllTokenDataForAddress(
-          client.kernelAccountAddress,
-          [tokenConfig],
-        )
+        const tokenOut: TokenData = {
+          chainId: candidateToken.chainId,
+          config: tokenConfig,
+          balance: {
+            address: candidateToken.token,
+            decimals: 0, // Placeholder. This is not used for LiFi quotes.
+            balance: 0n, // Placeholder. This is not used for LiFi quotes.
+          },
+        }
 
-        const liFiQuote = await this.liFiProviderService.getQuote(
-          tokenIn,
-          tokenData,
-          swapAmount,
-          id,
-        )
+        const liFiQuote = await this.liFiProviderService.getQuote(tokenIn, tokenOut, swapAmount, id)
 
         const outputAmount = BigInt(liFiQuote.context.toAmountMin)
         if (outputAmount > bestAmountOut) {
-          bestResult = { tokenData, quote: liFiQuote, outputAmount }
+          bestResult = { tokenData: tokenOut, quote: liFiQuote, outputAmount }
           bestAmountOut = outputAmount
           this.logger.debug(
             EcoLogMessage.withId({


### PR DESCRIPTION
This PR fixes the issue of warp routes failing to rebalance.

We were trying to get balances of destination tokens, which is not necessary and was causing this error:

https://app.datadoghq.com/logs?query=service%3Aeco-solver%20%40id%3A6f86848d-f11f-4770-bc4c-8d125442417d&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1751581619544&to_ts=1752877619544&live=true