### PR TITLE
Replace AWS secrets id using ENVs

### DIFF
--- a/config/staging.ts
+++ b/config/staging.ts
@@ -6,15 +6,19 @@ export default {
   aws: [
     {
       region: 'us-east-2',
-      secretID: 'eco-solver-secrets-staging',
+      secretID: process.env.AWS_SECRET_ID_MISC || 'eco-solver-secrets-staging',
     },
     {
       region: 'us-east-2',
-      secretID: 'eco-solver-configs-staging',
+      secretID: process.env.AWS_SECRET_ID_CONFIGS || 'eco-solver-configs-staging',
     },
     {
       region: 'us-east-2',
-      secretID: 'eco-solver-whitelist-staging',
+      secretID: process.env.AWS_SECRET_ID_CHAINS || 'eco-solver-configs-chains-staging',
+    },
+    {
+      region: 'us-east-2',
+      secretID: process.env.AWS_SECRET_ID_WHITELIST || 'eco-solver-whitelist-staging',
     },
   ],
   //don't add anything else here


### PR DESCRIPTION
This pull request updates the AWS configuration in the `staging` environment to support environment-specific overrides for secret IDs. The changes improve flexibility by allowing secret IDs to be dynamically set via environment variables, with fallbacks to default values.

### Configuration updates for AWS secret IDs:

* `config/staging.ts`: Modified the `secretID` fields to use environment variables (`process.env`) for dynamic assignment, with fallback values for the following keys:
  - `AWS_SECRET_ID_MISC`
  - `AWS_SECRET_ID_CONFIGS`
  - `AWS_SECRET_ID_CHAINS`
  - `AWS_SECRET_ID_WHITELIST`