### PR TITLE
Crowd Liquidity - Retry logic for CL fulfillments

### DIFF
--- a/config/default.ts
+++ b/config/default.ts
@@ -94,7 +94,7 @@ export default {
   },
 
   quotesConfig: {
-    intentExecutionTypes: ['SELF_PUBLISH', 'GASLESS'],
+    intentExecutionTypes: ['SELF_PUBLISH', 'GASLESS', 'CROWD_LIQUIDITY'],
   },
 
   gaslessIntentdAppIDs: ['token-pair-validation', 'matrix-test', 'test', 'sdk-demo'],

--- a/config/default.ts
+++ b/config/default.ts
@@ -50,6 +50,24 @@ export default {
           delay: 2_000,
         },
       },
+      crowdLiquidityJobConfig: {
+        removeOnComplete: false,
+        removeOnFail: false,
+        attempts: 5,
+        backoff: {
+          type: 'exponential',
+          delay: 3_000,
+        },
+      },
+      walletFulfillJobConfig: {
+        removeOnComplete: false,
+        removeOnFail: false,
+        attempts: 3,
+        backoff: {
+          type: 'exponential',
+          delay: 2_000,
+        },
+      },
       watchJobConfig: {
         removeOnComplete: true,
         removeOnFail: false,

--- a/src/common/redis/constants.ts
+++ b/src/common/redis/constants.ts
@@ -7,6 +7,8 @@ export const QUEUES: Record<any, QueueInterface> = {
       validate_intent: 'validate_intent',
       feasable_intent: 'feasable_intent',
       fulfill_intent: 'fulfill_intent',
+      fulfill_intent_crowd_liquidity: 'fulfill_intent_crowd_liquidity',
+      fulfill_intent_wallet: 'fulfill_intent_wallet',
       retry_intent: 'retry_intent',
     },
   },

--- a/src/eco-configs/eco-config.types.ts
+++ b/src/eco-configs/eco-config.types.ts
@@ -122,6 +122,8 @@ export type RedisConfig = {
   redlockSettings?: Partial<Settings>
   jobs: {
     intentJobConfig: JobsOptions
+    crowdLiquidityJobConfig: JobsOptions
+    walletFulfillJobConfig: JobsOptions
     watchJobConfig: JobsOptions
   }
 }

--- a/src/eco-configs/eco-config.types.ts
+++ b/src/eco-configs/eco-config.types.ts
@@ -438,6 +438,7 @@ export interface HyperlaneConfig {
 }
 
 export interface CrowdLiquidityConfig {
+  enabled?: boolean
   litNetwork: LIT_NETWORKS_KEYS
   capacityTokenOwnerPk: string
   defaultTargetBalance: number

--- a/src/eco-configs/eco-config.types.ts
+++ b/src/eco-configs/eco-config.types.ts
@@ -451,7 +451,7 @@ export interface CrowdLiquidityConfig {
     publicKey: string
   }
   supportedTokens: { chainId: number; tokenAddress: Hex }[]
-  minExcessFees: Record<number, bigint>
+  minExcessFees: Record<number, string>
 }
 
 export interface CCTPConfig {

--- a/src/eco-configs/eco-config.types.ts
+++ b/src/eco-configs/eco-config.types.ts
@@ -450,6 +450,7 @@ export interface CrowdLiquidityConfig {
     publicKey: string
   }
   supportedTokens: { chainId: number; tokenAddress: Hex }[]
+  minExcessFees: Record<number, bigint>
 }
 
 export interface CCTPConfig {

--- a/src/intent/crowd-liquidity.service.ts
+++ b/src/intent/crowd-liquidity.service.ts
@@ -304,7 +304,7 @@ export class CrowdLiquidityService implements OnModuleInit, IFulfillService {
 
     const totalRewardAmount = reward.tokens.reduce((acc, token) => acc + token.amount, 0n)
 
-    const minExcessFee = this.config.minExcessFees[Number(route.destination)] ?? 0n
+    const minExcessFee = BigInt(this.config.minExcessFees[Number(route.destination)] ?? '0')
 
     const minimumReward = totalRouteAmount + executionFee + minExcessFee
     const isEnough = totalRewardAmount >= minimumReward

--- a/src/intent/crowd-liquidity.service.ts
+++ b/src/intent/crowd-liquidity.service.ts
@@ -334,7 +334,7 @@ export class CrowdLiquidityService implements OnModuleInit, IFulfillService {
     return isEnough
   }
 
-  protected async getExecutionFee(
+  public async getExecutionFee(
     intentModel: IntentDataModel,
     totalRouteAmount: bigint,
     proverFee: bigint,

--- a/src/intent/fulfill-intent.service.ts
+++ b/src/intent/fulfill-intent.service.ts
@@ -1,15 +1,16 @@
 import { Injectable, Logger } from '@nestjs/common'
+import { InjectQueue } from '@nestjs/bullmq'
+import { Queue } from 'bullmq'
 import { Hex } from 'viem'
 import { UtilsIntentService } from './utils-intent.service'
-import { EcoLogMessage } from '@/common/logging/eco-log-message'
-import { Solver } from '@/eco-configs/eco-config.types'
 import { EcoConfigService } from '@/eco-configs/eco-config.service'
-import { IntentSourceModel } from '@/intent/schemas/intent-source.schema'
 import { WalletFulfillService } from '@/intent/wallet-fulfill.service'
 import { CrowdLiquidityService } from '@/intent/crowd-liquidity.service'
 import { isNativeIntent } from './utils'
 import { EcoAnalyticsService } from '@/analytics'
 import { ANALYTICS_EVENTS, ERROR_EVENTS } from '@/analytics/events.constants'
+import { QUEUES } from '@/common/redis/constants'
+import { getIntentJobId } from '@/common/utils/strings'
 
 /**
  * This class fulfills an intent by creating the transactions for the intent targets and the fulfill intent transaction.
@@ -19,6 +20,7 @@ export class FulfillIntentService {
   private logger = new Logger(FulfillIntentService.name)
 
   constructor(
+    @InjectQueue(QUEUES.SOURCE_INTENT.queue) private readonly intentQueue: Queue,
     private readonly utilsIntentService: UtilsIntentService,
     private readonly ecoConfigService: EcoConfigService,
     private readonly walletFulfillService: WalletFulfillService,
@@ -28,6 +30,7 @@ export class FulfillIntentService {
 
   /**
    * Processes and fulfills a specified intent based on its type.
+   * This method decides which fulfillment strategy to use and creates the appropriate job.
    *
    * @param {Hex} intentHash - The unique hash identifier of the intent to be fulfilled.
    * @return {Promise<void>} Returns the result of the fulfillment process based on the intent type.
@@ -92,89 +95,200 @@ export class FulfillIntentService {
       solver,
     )
 
-    switch (type) {
-      case 'crowd-liquidity':
-        return this.executeFulfillIntentWithCL(model, solver)
-      default:
-        return this.walletFulfillService.fulfill(model, solver)
-    }
-  }
+    // Create the appropriate job based on fulfillment type
+    if (type === 'crowd-liquidity' && !isNative) {
+      // Check if crowd liquidity route is supported
+      const isRouteSupported = this.crowdLiquidityService.isRouteSupported(model)
 
-  /**
-   * Executes the fulfillment of an intent using crowd liquidity.
-   *
-   * @param {IntentSourceModel} model - The model representing the intent to be fulfilled.
-   * @param {Solver} solver - The solver responsible for executing the fulfillment of the intent.
-   * @return {Promise<void>} A promise that resolves when the intent fulfillment is successfully executed.
-   */
-  async executeFulfillIntentWithCL(model: IntentSourceModel, solver: Solver): Promise<Hex> {
-    const isRouteSupported = this.crowdLiquidityService.isRouteSupported(model)
+      // Track crowd liquidity route support check
+      this.ecoAnalytics.trackSuccess(ANALYTICS_EVENTS.INTENT.CROWD_LIQUIDITY_ROUTE_CHECK, {
+        intentHash: model.intent.hash,
+        model,
+        solver,
+        routeSupported: isRouteSupported,
+      })
 
-    // Track crowd liquidity route support check
-    this.ecoAnalytics.trackSuccess(ANALYTICS_EVENTS.INTENT.CROWD_LIQUIDITY_ROUTE_CHECK, {
-      intentHash: model.intent.hash,
-      model,
-      solver,
-      routeSupported: isRouteSupported,
-    })
+      if (isRouteSupported) {
+        // Create crowd liquidity job
+        const jobId = getIntentJobId('crowd-liquidity', intentHash, model.intent.logIndex)
+        const crowdLiquidityJobConfig =
+          this.ecoConfigService.getRedis().jobs.crowdLiquidityJobConfig
 
-    if (isRouteSupported) {
-      try {
-        // Track crowd liquidity fulfillment attempt
-        this.ecoAnalytics.trackSuccess(
-          ANALYTICS_EVENTS.INTENT.CROWD_LIQUIDITY_FULFILLMENT_STARTED,
+        this.logger.debug(
+          `Creating crowd liquidity fulfillment job for ${intentHash} with jobId ${jobId}`,
+        )
+
+        await this.intentQueue.add(
+          QUEUES.SOURCE_INTENT.jobs.fulfill_intent_crowd_liquidity,
+          intentHash,
           {
-            intentHash: model.intent.hash,
-            model,
-            solver,
+            jobId,
+            ...crowdLiquidityJobConfig,
           },
         )
 
-        const result = await this.crowdLiquidityService.fulfill(model)
-
-        // Track successful crowd liquidity fulfillment
-        this.ecoAnalytics.trackSuccess(
-          ANALYTICS_EVENTS.INTENT.CROWD_LIQUIDITY_FULFILLMENT_SUCCEEDED,
-          {
-            intentHash: model.intent.hash,
-            model,
-            solver,
-            transactionHash: result,
-          },
+        return
+      } else {
+        // Route not supported, fall back to wallet fulfillment
+        this.logger.debug(
+          `Crowd liquidity route not supported for ${intentHash}, falling back to wallet fulfillment`,
         )
 
-        return result
-      } catch (error) {
-        this.logger.error(
-          EcoLogMessage.withError({
-            message: 'Failed to fulfill using Crowd Liquidity, proceeding to use solver',
-            properties: { intentHash: model.intent.hash },
-            error,
-          }),
-        )
-
-        // Track crowd liquidity fulfillment failure and fallback
-        this.ecoAnalytics.trackError(
-          ANALYTICS_EVENTS.INTENT.CROWD_LIQUIDITY_FULFILLMENT_FAILED,
-          error,
-          {
-            intentHash: model.intent.hash,
-            model,
-            solver,
-            fallbackToWallet: true,
-          },
-        )
+        this.ecoAnalytics.trackSuccess(ANALYTICS_EVENTS.INTENT.WALLET_FULFILLMENT_FALLBACK, {
+          intentHash,
+          model,
+          solver,
+          reason: 'route_not_supported',
+        })
       }
     }
 
-    // If crowd liquidity is not available for current route, or it failed to fulfill the intent
-    // Fulfill the intent using the solver
-    this.ecoAnalytics.trackSuccess(ANALYTICS_EVENTS.INTENT.WALLET_FULFILLMENT_FALLBACK, {
+    // Create wallet fulfillment job (either as primary choice or fallback)
+    const jobId = getIntentJobId('wallet-fulfill', intentHash, model.intent.logIndex)
+    const walletFulfillJobConfig = this.ecoConfigService.getRedis().jobs.walletFulfillJobConfig
+
+    this.logger.debug(`Creating wallet fulfillment job for ${intentHash} with jobId ${jobId}`)
+
+    await this.intentQueue.add(QUEUES.SOURCE_INTENT.jobs.fulfill_intent_wallet, intentHash, {
+      jobId,
+      ...walletFulfillJobConfig,
+    })
+  }
+
+  /**
+   * Fulfills an intent using crowd liquidity only.
+   * This method is called directly from the crowd liquidity job.
+   *
+   * @param {Hex} intentHash - The unique hash identifier of the intent to be fulfilled.
+   * @return {Promise<Hex>} Returns the transaction hash of the fulfillment.
+   */
+  async fulfillWithCrowdLiquidity(intentHash: Hex): Promise<Hex> {
+    // Track fulfillment attempt start
+    this.ecoAnalytics.trackIntentFulfillmentStarted(intentHash)
+
+    const data = await this.utilsIntentService.getIntentProcessData(intentHash)
+    const { model, solver, err } = data ?? {}
+
+    if (err) {
+      // Track fulfillment failed due to data error
+      this.ecoAnalytics.trackError(ANALYTICS_EVENTS.INTENT.FULFILLMENT_FAILED, err, {
+        intentHash,
+        data,
+        reason: 'intent_data_error',
+        stage: 'data_retrieval',
+        method: 'crowd_liquidity',
+      })
+      throw err
+    }
+
+    if (!data || !model || !solver) {
+      // Track fulfillment failed due to missing data
+      const error = new Error('missing_model_or_solver')
+      this.ecoAnalytics.trackError(ERROR_EVENTS.INTENT_FULFILLMENT_FAILED, error, {
+        intentHash,
+        data,
+        model,
+        solver,
+        reason: 'missing_model_or_solver',
+        stage: 'data_retrieval',
+        method: 'crowd_liquidity',
+      })
+      throw error
+    }
+
+    if (model.status === 'SOLVED') {
+      // Track already solved intent
+      this.ecoAnalytics.trackSuccess(ANALYTICS_EVENTS.INTENT.FULFILLMENT_SKIPPED, {
+        intentHash,
+        model,
+        solver,
+        reason: 'already_solved',
+        method: 'crowd_liquidity',
+      })
+      return '0x0' as Hex
+    }
+
+    // Track crowd liquidity fulfillment attempt
+    this.ecoAnalytics.trackSuccess(ANALYTICS_EVENTS.INTENT.CROWD_LIQUIDITY_FULFILLMENT_STARTED, {
       intentHash: model.intent.hash,
       model,
       solver,
-      reason: isRouteSupported ? 'crowd_liquidity_failed' : 'route_not_supported',
     })
+
+    const result = await this.crowdLiquidityService.fulfill(model)
+
+    // Track successful crowd liquidity fulfillment
+    this.ecoAnalytics.trackSuccess(ANALYTICS_EVENTS.INTENT.CROWD_LIQUIDITY_FULFILLMENT_SUCCEEDED, {
+      intentHash: model.intent.hash,
+      model,
+      solver,
+      transactionHash: result,
+    })
+
+    return result
+  }
+
+  /**
+   * Fulfills an intent using wallet fulfillment only.
+   * This method is called directly from the wallet fulfill job.
+   *
+   * @param {Hex} intentHash - The unique hash identifier of the intent to be fulfilled.
+   * @return {Promise<Hex>} Returns the transaction hash of the fulfillment.
+   */
+  async fulfillWithWallet(intentHash: Hex): Promise<Hex> {
+    // Track fulfillment attempt start
+    this.ecoAnalytics.trackIntentFulfillmentStarted(intentHash)
+
+    const data = await this.utilsIntentService.getIntentProcessData(intentHash)
+    const { model, solver, err } = data ?? {}
+
+    if (err) {
+      // Track fulfillment failed due to data error
+      this.ecoAnalytics.trackError(ANALYTICS_EVENTS.INTENT.FULFILLMENT_FAILED, err, {
+        intentHash,
+        data,
+        reason: 'intent_data_error',
+        stage: 'data_retrieval',
+        method: 'wallet',
+      })
+      throw err
+    }
+
+    if (!data || !model || !solver) {
+      // Track fulfillment failed due to missing data
+      const error = new Error('missing_model_or_solver')
+      this.ecoAnalytics.trackError(ERROR_EVENTS.INTENT_FULFILLMENT_FAILED, error, {
+        intentHash,
+        data,
+        model,
+        solver,
+        reason: 'missing_model_or_solver',
+        stage: 'data_retrieval',
+        method: 'wallet',
+      })
+      throw error
+    }
+
+    if (model.status === 'SOLVED') {
+      // Track already solved intent
+      this.ecoAnalytics.trackSuccess(ANALYTICS_EVENTS.INTENT.FULFILLMENT_SKIPPED, {
+        intentHash,
+        model,
+        solver,
+        reason: 'already_solved',
+        method: 'wallet',
+      })
+      return '0x0' as Hex
+    }
+
+    // Track wallet fulfillment method selected
+    this.ecoAnalytics.trackIntentFulfillmentMethodSelected(
+      intentHash,
+      'smart-wallet-account',
+      false,
+      model,
+      solver,
+    )
 
     return this.walletFulfillService.fulfill(model, solver)
   }

--- a/src/intent/tests/crowd-liquidity.service.spec.ts
+++ b/src/intent/tests/crowd-liquidity.service.spec.ts
@@ -78,7 +78,7 @@ describe('CrowdLiquidityService', () => {
     beforeEach(() => {
       baseConfig = {
         minExcessFees: {
-          1: 100n,
+          1: '100',
         },
         litNetwork: 'cayenne' as LIT_NETWORKS_KEYS,
         capacityTokenOwnerPk: MOCK_ADDR_1,
@@ -145,7 +145,7 @@ describe('CrowdLiquidityService', () => {
     beforeEach(() => {
       baseConfig = {
         minExcessFees: {
-          1: 100n,
+          1: '100',
         },
         litNetwork: 'cayenne' as LIT_NETWORKS_KEYS,
         capacityTokenOwnerPk: MOCK_ADDR_1,
@@ -184,7 +184,7 @@ describe('CrowdLiquidityService', () => {
     beforeEach(() => {
       baseConfig = {
         minExcessFees: {
-          1: 100n,
+          1: '100',
         },
         litNetwork: 'cayenne' as LIT_NETWORKS_KEYS,
         capacityTokenOwnerPk: MOCK_ADDR_1,

--- a/src/intent/tests/crowd-liquidity.service.spec.ts
+++ b/src/intent/tests/crowd-liquidity.service.spec.ts
@@ -1,0 +1,325 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { CrowdLiquidityService } from '../crowd-liquidity.service'
+import { EcoConfigService } from '@/eco-configs/eco-config.service'
+import { BalanceService } from '@/balance/balance.service'
+import { EcoAnalyticsService } from '@/analytics'
+import { IntentSourceModel, IntentSourceStatus } from '../schemas/intent-source.schema'
+import { CrowdLiquidityConfig } from '@/eco-configs/eco-config.types'
+import { Hex, GetTransactionReceiptReturnType } from 'viem'
+import { LIT_NETWORKS_KEYS } from '@lit-protocol/types'
+import { CACHE_MANAGER } from '@nestjs/cache-manager'
+import { WalletClientDefaultSignerService } from '@/transaction/smart-wallets/wallet-client.service'
+
+const MOCK_ADDR_1 = '0x1111111111111111111111111111111111111111' as Hex
+const MOCK_ADDR_2 = '0x2222222222222222222222222222222222222222' as Hex
+const MOCK_ADDR_3 = '0x3333333333333333333333333333333333333333' as Hex
+const MOCK_ADDR_4 = '0x4444444444444444444444444444444444444444' as Hex
+const MOCK_ADDR_5 = '0x5555555555555555555555555555555555555555' as Hex
+const MOCK_ADDR_6 = '0x6666666666666666666666666666666666666666' as Hex
+const MOCK_ADDR_7 = '0x7777777777777777777777777777777777777777' as Hex
+const MOCK_ADDR_8 = '0x8888888888888888888888888888888888888888' as Hex
+const MOCK_ADDR_9 = '0x9999999999999999999999999999999999999999' as Hex
+const MOCK_ADDR_UNSUPPORTED = '0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF' as Hex
+
+describe('CrowdLiquidityService', () => {
+  let service: CrowdLiquidityService
+  let ecoConfigService: EcoConfigService
+
+  const mockEcoConfigService = {
+    getCrowdLiquidity: jest.fn(),
+    getIntentSource: jest.fn(),
+  }
+
+  const mockBalanceService = {
+    getInboxTokens: jest.fn(),
+    getAllTokenDataForAddress: jest.fn(),
+  }
+  const mockEcoAnalytics = {
+    trackCrowdLiquidityRewardCheck: jest.fn(),
+    trackCrowdLiquidityRewardCheckResult: jest.fn(),
+    trackCrowdLiquidityRouteSupportCheck: jest.fn(),
+    trackCrowdLiquidityRouteSupportResult: jest.fn(),
+    trackCrowdLiquidityPoolSolvencyResult: jest.fn(),
+    trackCrowdLiquidityPoolSolvencyError: jest.fn(),
+  }
+  const mockWalletClientService = {
+    getClient: jest.fn(),
+  }
+  const mockCacheManager = {
+    get: jest.fn(),
+    set: jest.fn(),
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CrowdLiquidityService,
+        { provide: EcoConfigService, useValue: mockEcoConfigService },
+        { provide: BalanceService, useValue: mockBalanceService },
+        { provide: EcoAnalyticsService, useValue: mockEcoAnalytics },
+        { provide: CACHE_MANAGER, useValue: mockCacheManager },
+        { provide: WalletClientDefaultSignerService, useValue: mockWalletClientService },
+      ],
+    }).compile()
+
+    service = module.get<CrowdLiquidityService>(CrowdLiquidityService)
+    ecoConfigService = module.get<EcoConfigService>(EcoConfigService)
+    jest.clearAllMocks()
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+
+  describe('isRewardEnough', () => {
+    let baseConfig: CrowdLiquidityConfig
+    let intentModel: IntentSourceModel
+
+    beforeEach(() => {
+      baseConfig = {
+        minExcessFees: {
+          1: 100n,
+        },
+        litNetwork: 'cayenne' as LIT_NETWORKS_KEYS,
+        capacityTokenOwnerPk: MOCK_ADDR_1,
+        defaultTargetBalance: 1000,
+        actions: {
+          fulfill: 'fulfill-action',
+          rebalance: 'rebalance-action',
+        },
+        pkp: {
+          ethAddress: MOCK_ADDR_3,
+          publicKey: '0x04...',
+        },
+        supportedTokens: [],
+      }
+
+      intentModel = {
+        intent: {
+          route: {
+            destination: 1n,
+            tokens: [{ token: MOCK_ADDR_4, amount: 10000n }],
+            salt: MOCK_ADDR_5,
+            source: 2n,
+            inbox: MOCK_ADDR_6,
+            calls: [],
+          },
+          reward: {
+            tokens: [{ token: MOCK_ADDR_7, amount: 10200n }],
+            creator: MOCK_ADDR_8,
+            prover: MOCK_ADDR_9,
+            deadline: 1234567890n,
+            nativeValue: 0n,
+          },
+          hash: MOCK_ADDR_1,
+          logIndex: 1,
+        },
+        status: 'PENDING' as IntentSourceStatus,
+        receipt: {} as GetTransactionReceiptReturnType,
+      } as IntentSourceModel
+    })
+
+    it('should return true when reward is sufficient', async () => {
+      jest.spyOn(ecoConfigService, 'getCrowdLiquidity').mockReturnValue(baseConfig)
+      service.onModuleInit()
+      await expect(service.isRewardEnough(intentModel, 10000n, 100n)).resolves.toBe(true)
+    })
+
+    it('should return false when reward is not enough', async () => {
+      jest.spyOn(ecoConfigService, 'getCrowdLiquidity').mockReturnValue(baseConfig)
+      service.onModuleInit()
+      await expect(service.isRewardEnough(intentModel, 10000n, 101n)).resolves.toBe(false)
+    })
+
+    it('should work correctly when no min excess fee is configured for the chain', async () => {
+      const config = { ...baseConfig, minExcessFees: {} }
+      jest.spyOn(ecoConfigService, 'getCrowdLiquidity').mockReturnValue(config)
+      service.onModuleInit()
+      await expect(service.isRewardEnough(intentModel, 10100n, 100n)).resolves.toBe(true)
+    })
+  })
+
+  describe('isSupportedToken', () => {
+    let baseConfig: CrowdLiquidityConfig
+
+    beforeEach(() => {
+      baseConfig = {
+        minExcessFees: {
+          1: 100n,
+        },
+        litNetwork: 'cayenne' as LIT_NETWORKS_KEYS,
+        capacityTokenOwnerPk: MOCK_ADDR_1,
+        defaultTargetBalance: 1000,
+        actions: {
+          fulfill: 'fulfill-action',
+          rebalance: 'rebalance-action',
+        },
+        pkp: {
+          ethAddress: MOCK_ADDR_3,
+          publicKey: '0x04...',
+        },
+        supportedTokens: [{ chainId: 1, tokenAddress: MOCK_ADDR_4 }],
+      }
+      jest.spyOn(ecoConfigService, 'getCrowdLiquidity').mockReturnValue(baseConfig)
+      service.onModuleInit()
+    })
+
+    it('should return true if token is supported', () => {
+      expect(service.isSupportedToken(1, MOCK_ADDR_4)).toBe(true)
+    })
+
+    it('should return false if token is not supported', () => {
+      expect(service.isSupportedToken(1, MOCK_ADDR_UNSUPPORTED)).toBe(false)
+    })
+
+    it('should return false if chain is not supported', () => {
+      expect(service.isSupportedToken(2, MOCK_ADDR_4)).toBe(false)
+    })
+  })
+
+  describe('isRouteSupported', () => {
+    let intentModel: IntentSourceModel
+    let baseConfig: CrowdLiquidityConfig
+
+    beforeEach(() => {
+      baseConfig = {
+        minExcessFees: {
+          1: 100n,
+        },
+        litNetwork: 'cayenne' as LIT_NETWORKS_KEYS,
+        capacityTokenOwnerPk: MOCK_ADDR_1,
+        defaultTargetBalance: 1000,
+        actions: {
+          fulfill: 'fulfill-action',
+          rebalance: 'rebalance-action',
+        },
+        pkp: {
+          ethAddress: MOCK_ADDR_3,
+          publicKey: '0x04...',
+        },
+        supportedTokens: [
+          { chainId: 1, tokenAddress: MOCK_ADDR_4 },
+          { chainId: 2, tokenAddress: MOCK_ADDR_5 },
+        ],
+      }
+      jest.spyOn(ecoConfigService, 'getCrowdLiquidity').mockReturnValue(baseConfig)
+      service.onModuleInit()
+
+      intentModel = {
+        intent: {
+          route: {
+            source: 1n,
+            destination: 2n,
+            calls: [{ target: MOCK_ADDR_5, data: '0xa9059cbb' as Hex, value: 0n }],
+            salt: MOCK_ADDR_6,
+            inbox: MOCK_ADDR_7,
+            tokens: [],
+          },
+          reward: {
+            tokens: [{ token: MOCK_ADDR_4, amount: 1n }],
+            creator: MOCK_ADDR_8,
+            prover: MOCK_ADDR_9,
+            deadline: 0n,
+            nativeValue: 0n,
+          },
+          hash: MOCK_ADDR_1,
+          logIndex: 0,
+        },
+        status: 'PENDING',
+        receipt: {} as any,
+      } as IntentSourceModel
+    })
+
+    it('should return true for a fully supported route', () => {
+      expect(service.isRouteSupported(intentModel)).toBe(true)
+    })
+
+    it('should return false for an unsupported reward token', () => {
+      intentModel.intent.reward.tokens = [{ token: MOCK_ADDR_UNSUPPORTED, amount: 1n }]
+      expect(service.isRouteSupported(intentModel)).toBe(false)
+    })
+
+    it('should return false for an unsupported target token', () => {
+      intentModel.intent.route.calls = [
+        { target: MOCK_ADDR_UNSUPPORTED, data: '0xa9059cbb' as Hex, value: 0n },
+      ]
+      expect(service.isRouteSupported(intentModel)).toBe(false)
+    })
+
+    it('should return false for an unsupported action', () => {
+      intentModel.intent.route.calls = [
+        { target: MOCK_ADDR_5, data: '0xdeadbeef' as Hex, value: 0n },
+      ]
+      expect(service.isRouteSupported(intentModel)).toBe(false)
+    })
+  })
+
+  describe('getSupportedTokens', () => {
+    it('should return only supported tokens with their target balance', () => {
+      const config = {
+        supportedTokens: [{ chainId: 1, tokenAddress: MOCK_ADDR_1 }],
+        defaultTargetBalance: 500,
+      } as CrowdLiquidityConfig
+      jest.spyOn(ecoConfigService, 'getCrowdLiquidity').mockReturnValue(config)
+
+      const inboxTokens = [
+        { chainId: 1, address: MOCK_ADDR_1, name: 'ABC', decimals: 18, symbol: 'ABC' },
+        { chainId: 2, address: MOCK_ADDR_2, name: 'DEF', decimals: 18, symbol: 'DEF' },
+      ]
+      mockBalanceService.getInboxTokens.mockReturnValue(inboxTokens)
+
+      service.onModuleInit()
+
+      const supportedTokens = service.getSupportedTokens()
+      expect(supportedTokens).toHaveLength(1)
+      expect(supportedTokens[0]).toEqual({
+        ...inboxTokens[0],
+        targetBalance: 500,
+      })
+    })
+  })
+
+  describe('isPoolSolvent', () => {
+    let intentModel: IntentSourceModel
+
+    beforeEach(() => {
+      const config = {
+        supportedTokens: [{ chainId: 1, tokenAddress: MOCK_ADDR_1 }],
+      } as CrowdLiquidityConfig
+      jest.spyOn(ecoConfigService, 'getCrowdLiquidity').mockReturnValue(config)
+      jest
+        .spyOn(ecoConfigService, 'getIntentSource')
+        .mockReturnValue({ stablePoolAddress: MOCK_ADDR_2 } as any)
+
+      const inboxTokens = [
+        { chainId: 1, address: MOCK_ADDR_1, name: 'ABC', decimals: 18, symbol: 'ABC' },
+      ]
+      mockBalanceService.getInboxTokens.mockReturnValue(inboxTokens)
+
+      intentModel = {
+        intent: {
+          route: {
+            destination: 1n,
+            tokens: [{ token: MOCK_ADDR_1, amount: 100n }],
+          },
+        },
+      } as any
+    })
+
+    it('should return true if pool has sufficient balance', async () => {
+      const tokenData = [{ config: { address: MOCK_ADDR_1 }, balance: { balance: 150n } }]
+      mockBalanceService.getAllTokenDataForAddress.mockResolvedValue(tokenData)
+      service.onModuleInit()
+
+      await expect(service.isPoolSolvent(intentModel)).resolves.toBe(true)
+    })
+
+    it('should return false if pool has insufficient balance', async () => {
+      const tokenData = [{ config: { address: MOCK_ADDR_1 }, balance: { balance: 50n } }]
+      mockBalanceService.getAllTokenDataForAddress.mockResolvedValue(tokenData)
+      service.onModuleInit()
+
+      await expect(service.isPoolSolvent(intentModel)).resolves.toBe(false)
+    })
+  })
+})

--- a/src/quote/additional-quote.service.spec.ts
+++ b/src/quote/additional-quote.service.spec.ts
@@ -11,6 +11,8 @@ import { QuoteRepository } from '@/quote/quote.repository'
 import { QuoteService } from '@/quote/quote.service'
 import { QuoteTestUtils } from '@/intent-initiation/test-utils/quote-test-utils'
 import { ValidationChecks, ValidationService } from '@/intent/validation.sevice'
+import { CrowdLiquidityService } from '@/intent/crowd-liquidity.service'
+import { createMock } from '@golevelup/ts-jest'
 
 const logger = new Logger('QuoteServiceSpec')
 
@@ -64,21 +66,16 @@ describe('QuoteService', () => {
             assertValidations: mockAssertValidations,
           },
         },
+        {
+          provide: CrowdLiquidityService,
+          useValue: createMock<CrowdLiquidityService>(),
+        },
       ])
       .withMocks([
         IntentInitiationService,
         FulfillmentEstimateService,
         QuoteRepository,
         EcoAnalyticsService,
-        {
-          provide: EcoConfigService,
-          useValue: {
-            getQuotesConfig: () => ({
-              intentExecutionTypes: ['GASLESS', 'SELF_PUBLISH'],
-            }),
-            getSolver: () => ({ chainID: 31337 }), // basic stub
-          },
-        },
       ])
 
     quoteService = await $.init()
@@ -98,7 +95,7 @@ describe('QuoteService', () => {
       })
 
       jest.spyOn(feeService, 'isRewardFeasible').mockResolvedValue({})
-      jest.spyOn(intentInitiationService, 'getGasPrice').mockResolvedValue(parseGwei('50'))
+      jest.spyOn(intentInitiationService, 'getGasPrice').mockResolvedValue(parseGwei('35'))
 
       const successfulValidations: ValidationChecks = {
         supportedProver: true,
@@ -330,7 +327,7 @@ describe('QuoteService', () => {
       const expectedFee = expectedGas * mockGasPrice
 
       expect(result).toBe(expectedFee)
-      expect(intentInitiationService.getGasPrice).toHaveBeenCalled()
+      expect(intentInitiationService.getGasPrice).toHaveBeenCalledWith(chainID, parseGwei('30'))
     })
   })
 })

--- a/src/quote/enums/intent-execution-type.enum.ts
+++ b/src/quote/enums/intent-execution-type.enum.ts
@@ -3,6 +3,7 @@ import { Enumify } from 'enumify'
 export class IntentExecutionType extends Enumify {
   static SELF_PUBLISH = new IntentExecutionType()
   static GASLESS = new IntentExecutionType()
+  static CROWD_LIQUIDITY = new IntentExecutionType()
   static _ = IntentExecutionType.closeEnum()
 
   static fromString(enumstr: string): IntentExecutionType | undefined {
@@ -23,9 +24,13 @@ export class IntentExecutionType extends Enumify {
     return this === IntentExecutionType.GASLESS
   }
 
+  isCrowdLiquidity(): boolean {
+    return this === IntentExecutionType.CROWD_LIQUIDITY
+  }
+
   toString() {
     return this.enumKey
   }
 }
 
-export const IntentExecutionTypeKeys = ['SELF_PUBLISH', 'GASLESS'] as const
+export const IntentExecutionTypeKeys = ['SELF_PUBLISH', 'GASLESS', 'CROWD_LIQUIDITY'] as const

--- a/src/quote/quote.module.ts
+++ b/src/quote/quote.module.ts
@@ -3,6 +3,7 @@ import { QuoteService } from './quote.service'
 import { MongooseModule } from '@nestjs/mongoose'
 import { QuoteIntentModel, QuoteIntentSchema } from '@/quote/schemas/quote-intent.schema'
 import { IntentModule } from '@/intent/intent.module'
+import { IntentInitiationModule } from '@/intent-initiation/intent-initiation.module'
 import { FeeModule } from '@/fee/fee.module'
 import { QuoteRepository } from '@/quote/quote.repository'
 import { FulfillmentEstimateModule } from '@/fulfillment-estimate/fulfillment-estimate.module'
@@ -11,6 +12,7 @@ import { FulfillmentEstimateModule } from '@/fulfillment-estimate/fulfillment-es
   imports: [
     FeeModule,
     IntentModule,
+    IntentInitiationModule,
     FulfillmentEstimateModule,
     MongooseModule.forFeature([{ name: QuoteIntentModel.name, schema: QuoteIntentSchema }]),
   ],

--- a/src/quote/quote.module.ts
+++ b/src/quote/quote.module.ts
@@ -6,6 +6,7 @@ import { IntentModule } from '@/intent/intent.module'
 import { FeeModule } from '@/fee/fee.module'
 import { QuoteRepository } from '@/quote/quote.repository'
 import { FulfillmentEstimateModule } from '@/fulfillment-estimate/fulfillment-estimate.module'
+
 @Module({
   imports: [
     FeeModule,

--- a/src/quote/quote.service.ts
+++ b/src/quote/quote.service.ts
@@ -867,7 +867,9 @@ export class QuoteService implements OnModuleInit {
     const totalRouteAmount = route.tokens.reduce((acc, token) => acc + token.amount, 0n)
 
     const crowdLiquidityConfig = this.ecoConfigService.getCrowdLiquidity()
-    const minExcessFee = crowdLiquidityConfig.minExcessFees[Number(route.destination)] ?? 0n
+    const minExcessFee = BigInt(
+      crowdLiquidityConfig.minExcessFees[Number(route.destination)] ?? '0',
+    )
 
     const intentSourceModel = this.quoteIntentToIntenSource(quoteIntentModel)
     const executionFee = await this.crowdLiquidityService.getExecutionFee(

--- a/src/quote/tests/quote.service.spec.ts
+++ b/src/quote/tests/quote.service.spec.ts
@@ -30,6 +30,7 @@ import { Chain, PublicClient, Transport } from 'viem'
 import { EcoAnalyticsService } from '@/analytics'
 import { UpdateQuoteParams } from '@/quote/interfaces/update-quote-params.interface'
 import { EcoError } from '@/common/errors/eco-error'
+import { CrowdLiquidityService } from '@/intent/crowd-liquidity.service'
 
 jest.mock('@/intent/utils', () => {
   return {
@@ -58,6 +59,7 @@ describe('QuotesService', () => {
   let ecoConfigService: DeepMocked<EcoConfigService>
   let quoteModel: DeepMocked<Model<QuoteIntentModel>>
   let fulfillmentEstimateService: DeepMocked<FulfillmentEstimateService>
+  let crowdLiquidityService: DeepMocked<CrowdLiquidityService>
   const mockLogDebug = jest.fn()
   const mockLogLog = jest.fn()
   const mockLogError = jest.fn()
@@ -89,6 +91,7 @@ describe('QuotesService', () => {
         },
         { provide: FulfillmentEstimateService, useValue: createMock<FulfillmentEstimateService>() },
         { provide: EcoAnalyticsService, useValue: createMock<EcoAnalyticsService>() },
+        { provide: CrowdLiquidityService, useValue: createMock<CrowdLiquidityService>() },
       ],
     }).compile()
 
@@ -96,6 +99,7 @@ describe('QuotesService', () => {
     quoteRepository = chainMod.get(QuoteRepository)
     feeService = chainMod.get(FeeService)
     validationService = chainMod.get(ValidationService)
+    crowdLiquidityService = chainMod.get(CrowdLiquidityService)
 
     ecoConfigService = chainMod.get(EcoConfigService)
     quoteModel = chainMod.get(getModelToken(QuoteIntentModel.name))
@@ -898,6 +902,71 @@ describe('QuotesService', () => {
       expect(response).toEqual(updatedDoc)
       expect(quoteRepository.updateQuoteDb).toHaveBeenCalledTimes(1)
       expect(quoteRepository.updateQuoteDb).toHaveBeenCalledWith(quoteIntentModel, updateParams)
+    })
+  })
+
+  describe('CrowdLiquidity Quotes', () => {
+    const quoteIntentData = quoteTestUtils.createQuoteIntentDataDTO({
+      intentExecutionTypes: [IntentExecutionType.CROWD_LIQUIDITY.toString()],
+    })
+    const quoteIntentModel = quoteTestUtils.getQuoteIntentModel(
+      quoteIntentData.intentExecutionTypes[0],
+      quoteIntentData,
+    )
+
+    it('should generate a CrowdLiquidity quote when enabled and eligible', async () => {
+      ecoConfigService.getCrowdLiquidity.mockReturnValue({ enabled: true } as any)
+      crowdLiquidityService.isRouteSupported.mockReturnValue(true)
+      crowdLiquidityService.isPoolSolvent.mockResolvedValue(true)
+      jest
+        .spyOn(quoteService as any, '_generateCrowdLiquidityQuote')
+        .mockResolvedValue({ response: {} })
+
+      const { response, error } = await quoteService['generateQuoteForCrowdLiquidity']({
+        quoteIntent: quoteIntentModel,
+      } as any)
+
+      expect(error).toBeUndefined()
+      expect(response).toBeDefined()
+      expect(crowdLiquidityService.isRouteSupported).toHaveBeenCalled()
+      expect(crowdLiquidityService.isPoolSolvent).toHaveBeenCalled()
+      expect(quoteService['_generateCrowdLiquidityQuote']).toHaveBeenCalled()
+    })
+
+    it('should return an error when CL is disabled', async () => {
+      ecoConfigService.getCrowdLiquidity.mockReturnValue({ enabled: false } as any)
+
+      const { error } = await quoteService['generateQuoteForCrowdLiquidity']({
+        quoteIntent: quoteIntentModel,
+      } as any)
+
+      expect(error).toBeDefined()
+      expect(error.message).toContain('CrowdLiquidity quoting is disabled')
+    })
+
+    it('should return an error when route is not supported by CL', async () => {
+      ecoConfigService.getCrowdLiquidity.mockReturnValue({ enabled: true } as any)
+      crowdLiquidityService.isRouteSupported.mockReturnValue(false)
+
+      const { error } = await quoteService['generateQuoteForCrowdLiquidity']({
+        quoteIntent: quoteIntentModel,
+      } as any)
+
+      expect(error).toBeDefined()
+      expect(error.message).toContain('Route not supported by CrowdLiquidity')
+    })
+
+    it('should return an error when CL pool is not solvent', async () => {
+      ecoConfigService.getCrowdLiquidity.mockReturnValue({ enabled: true } as any)
+      crowdLiquidityService.isRouteSupported.mockReturnValue(true)
+      crowdLiquidityService.isPoolSolvent.mockResolvedValue(false)
+
+      const { error } = await quoteService['generateQuoteForCrowdLiquidity']({
+        quoteIntent: quoteIntentModel,
+      } as any)
+
+      expect(error).toBeDefined()
+      expect(error.message).toContain('CrowdLiquidity pool is not solvent')
     })
   })
 })

--- a/src/quote/utils/transformers.ts
+++ b/src/quote/utils/transformers.ts
@@ -1,0 +1,36 @@
+import { QuoteIntentModel } from '@/quote/schemas/quote-intent.schema'
+import { QuoteIntentDataDTO } from '@/quote/dto/quote.intent.data.dto'
+import { GaslessIntentRequestDTO } from '@/quote/dto/gasless-intent-request.dto'
+import { IntentSourceModel, IntentSourceStatus } from '@/intent/schemas/intent-source.schema'
+
+const ZERO_SALT = '0x0000000000000000000000000000000000000000000000000000000000000000'
+
+export function quoteIntentToIntentSource(quoteIntent: QuoteIntentModel): IntentSourceModel {
+  return {
+    intent: {
+      ...quoteIntent,
+      route: {
+        ...quoteIntent.route,
+        salt: ZERO_SALT,
+      },
+      hash: '0x', // Placeholder hash
+      funder: '0x', // Placeholder funder
+      logIndex: 0, // Placeholder logIndex
+    },
+    status: 'PENDING' as IntentSourceStatus,
+    receipt: {} as any,
+  } as IntentSourceModel
+}
+
+export function getGaslessIntentRequest(
+  quoteIntentDataDTO: QuoteIntentDataDTO,
+): GaslessIntentRequestDTO {
+  return {
+    quoteID: quoteIntentDataDTO.quoteID,
+    dAppID: quoteIntentDataDTO.dAppID,
+    salt: ZERO_SALT,
+    route: quoteIntentDataDTO.route,
+    reward: quoteIntentDataDTO.reward,
+    gaslessIntentData: quoteIntentDataDTO.gaslessIntentData!,
+  }
+}


### PR DESCRIPTION
## Summary
  - Added separate job types for crowd liquidity and wallet fulfillment
  - Implemented retry logic with 5 attempts for crowd liquidity before falling back to wallet
  - Moved fulfillment type decision from feasible-intent service to fulfill_intent job
  - Added automatic wallet fulfillment job creation when crowd liquidity fails after all retries

  ## Changes
  - Added new job types: `fulfill_intent_crowd_liquidity` and `fulfill_intent_wallet`
  - Created separate job configurations with different retry settings
  - Updated SolveIntentProcessor to handle new job types and automatic fallback
  - Refactored FulfillIntentService to have separate methods for each fulfillment type
  - Fixed private field access in SolveIntentProcessor

  ## Test plan
  - [ ] Test successful crowd liquidity fulfillment
  - [ ] Test crowd liquidity retry mechanism
  - [ ] Test automatic fallback to wallet fulfillment after retries exhausted
  - [ ] Test direct wallet fulfillment for unsupported routes
  - [ ] Verify analytics tracking for all scenarios