### PR TITLE
Reject different token swaps on Everclear

### DIFF
--- a/src/liquidity-manager/jobs/eco-cron-job-manager.spec.ts
+++ b/src/liquidity-manager/jobs/eco-cron-job-manager.spec.ts
@@ -5,7 +5,7 @@ import { jest } from '@jest/globals'
 import { Job, Queue } from 'bullmq'
 import { LiquidityManagerJobName } from '@/liquidity-manager/queues/liquidity-manager.queue'
 
-jest.setTimeout(15000)
+jest.setTimeout(30000)
 
 describe('EcoCronJobManager', () => {
   let mockQueue: Queue


### PR DESCRIPTION
We are trying to use Everclear for different token swaps, which is not supported. But, instead of failing, Everclear will swap to a different token, which matches the source token. For instance, USDC/OP → USDT/ARB will be executed as USDC/OP → USDC/ARB.

So, different token swaps need to be rejected on our side when using Everclear.

https://eco.atlassian.net/browse/ED-5685