### PR TITLE
Improving robustness of rpc urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@0xsquid/squid-types": "^0.1.163",
     "@aws-sdk/client-kms": "^3.744.0",
     "@aws-sdk/client-secrets-manager": "^3.592.0",
-    "@eco-foundation/chains": "1.0.45",
+    "@eco-foundation/chains": "1.0.47",
     "@eco-foundation/eco-kms-core": "^2.0.0",
     "@eco-foundation/eco-kms-provider-aws": "^2.0.0",
     "@eco-foundation/eco-kms-wallets": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@0xsquid/squid-types": "^0.1.163",
     "@aws-sdk/client-kms": "^3.744.0",
     "@aws-sdk/client-secrets-manager": "^3.592.0",
-    "@eco-foundation/chains": "1.0.47",
+    "@eco-foundation/chains": "1.0.48",
     "@eco-foundation/eco-kms-core": "^2.0.0",
     "@eco-foundation/eco-kms-provider-aws": "^2.0.0",
     "@eco-foundation/eco-kms-wallets": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^3.592.0
         version: 3.848.0
       '@eco-foundation/chains':
-        specifier: 1.0.47
-        version: 1.0.47(@samchon/openapi@3.3.0)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+        specifier: 1.0.48
+        version: 1.0.48(@samchon/openapi@3.3.0)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@eco-foundation/eco-kms-core':
         specifier: ^2.0.0
         version: 2.0.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -663,8 +663,8 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@eco-foundation/chains@1.0.47':
-    resolution: {integrity: sha512-O3W3TH7mE29gT3ZxS4077oM0KsJRp66zp+OmMrav248E6muPmXq+UPcGU4XJ11REwv/XlRM+abrc1/Flyc/RwA==}
+  '@eco-foundation/chains@1.0.48':
+    resolution: {integrity: sha512-7tJxOasRT7MJPt8fpmnjzc5SHP8WWjJ2b1aYzRD/Nor64zFJ5Pb9TTP+iYhzovxEA0KEE3qZfSo4ET3gEnx15g==}
 
   '@eco-foundation/eco-kms-core@2.0.0':
     resolution: {integrity: sha512-hCYeg6/pQsFz1StA96FX8uG40g8H5Jj/Z4Vb0Si4yXNYZ8DdqiOHa2JYv5F24Vipu3vkSBIPllkhNisE8R83jg==}
@@ -6796,7 +6796,7 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@eco-foundation/chains@1.0.47(@samchon/openapi@3.3.0)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
+  '@eco-foundation/chains@1.0.48(@samchon/openapi@3.3.0)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
       typia: 8.2.0(@samchon/openapi@3.3.0)(typescript@5.8.3)
       viem: 2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^3.592.0
         version: 3.848.0
       '@eco-foundation/chains':
-        specifier: 1.0.45
-        version: 1.0.45(@samchon/openapi@3.3.0)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+        specifier: 1.0.47
+        version: 1.0.47(@samchon/openapi@3.3.0)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@eco-foundation/eco-kms-core':
         specifier: ^2.0.0
         version: 2.0.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -663,8 +663,8 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@eco-foundation/chains@1.0.45':
-    resolution: {integrity: sha512-QSfVdsepjPrZTcQ2kOsZHT87k8z0+U1/b5wEBA+hN9YBKw3eSpAjfi089khjTrBZ3CoTCuEhEGHKM+neNLiW7Q==}
+  '@eco-foundation/chains@1.0.47':
+    resolution: {integrity: sha512-O3W3TH7mE29gT3ZxS4077oM0KsJRp66zp+OmMrav248E6muPmXq+UPcGU4XJ11REwv/XlRM+abrc1/Flyc/RwA==}
 
   '@eco-foundation/eco-kms-core@2.0.0':
     resolution: {integrity: sha512-hCYeg6/pQsFz1StA96FX8uG40g8H5Jj/Z4Vb0Si4yXNYZ8DdqiOHa2JYv5F24Vipu3vkSBIPllkhNisE8R83jg==}
@@ -6796,7 +6796,7 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@eco-foundation/chains@1.0.45(@samchon/openapi@3.3.0)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
+  '@eco-foundation/chains@1.0.47(@samchon/openapi@3.3.0)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
       typia: 8.2.0(@samchon/openapi@3.3.0)(typescript@5.8.3)
       viem: 2.33.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)

--- a/src/common/chains/tests/transport.spec.ts
+++ b/src/common/chains/tests/transport.spec.ts
@@ -45,7 +45,7 @@ describe('getTransport', () => {
 
   it('should return a single websocket transport for a single websocket rpc url', () => {
     const rpcUrls = ['ws://test.rpc']
-    const transport = getTransport(rpcUrls, { isWebsocket: true })
+    const transport = getTransport(rpcUrls, { isWebsocketEnabled: true })
 
     expect(webSocket).toHaveBeenCalledWith(rpcUrls[0], { keepAlive: true, reconnect: true })
     expect(webSocket).toHaveBeenCalledTimes(1)
@@ -56,7 +56,7 @@ describe('getTransport', () => {
 
   it('should return a fallback transport for multiple websocket rpc urls', () => {
     const rpcUrls = ['ws://test.rpc', 'ws://test2.rpc']
-    const transport = getTransport(rpcUrls, { isWebsocket: true })
+    const transport = getTransport(rpcUrls, { isWebsocketEnabled: true })
 
     expect(webSocket).toHaveBeenCalledTimes(2)
     expect(webSocket).toHaveBeenCalledWith(rpcUrls[0], { keepAlive: true, reconnect: true })
@@ -76,7 +76,7 @@ describe('getTransport', () => {
 
   it('should pass websocket config to websocket transport', () => {
     const rpcUrls = ['ws://test.rpc']
-    const config = { isWebsocket: true, config: { key: 'test' } } as const
+    const config = { isWebsocketEnabled: true, config: { key: 'test' } } as const
     getTransport(rpcUrls, config)
     expect(webSocket).toHaveBeenCalledWith(rpcUrls[0], {
       keepAlive: true,

--- a/src/common/chains/tests/transport.spec.ts
+++ b/src/common/chains/tests/transport.spec.ts
@@ -45,7 +45,7 @@ describe('getTransport', () => {
 
   it('should return a single websocket transport for a single websocket rpc url', () => {
     const rpcUrls = ['ws://test.rpc']
-    const transport = getTransport(rpcUrls, { isWebsocketEnabled: true })
+    const transport = getTransport(rpcUrls)
 
     expect(webSocket).toHaveBeenCalledWith(rpcUrls[0], { keepAlive: true, reconnect: true })
     expect(webSocket).toHaveBeenCalledTimes(1)
@@ -56,7 +56,7 @@ describe('getTransport', () => {
 
   it('should return a fallback transport for multiple websocket rpc urls', () => {
     const rpcUrls = ['ws://test.rpc', 'ws://test2.rpc']
-    const transport = getTransport(rpcUrls, { isWebsocketEnabled: true })
+    const transport = getTransport(rpcUrls)
 
     expect(webSocket).toHaveBeenCalledTimes(2)
     expect(webSocket).toHaveBeenCalledWith(rpcUrls[0], { keepAlive: true, reconnect: true })
@@ -69,19 +69,19 @@ describe('getTransport', () => {
 
   it('should pass http config to http transport', () => {
     const rpcUrls = ['http://test.rpc']
-    const config = { config: { timeout: 1000 } }
+    const config = { timeout: 1000 }
     getTransport(rpcUrls, config)
-    expect(http).toHaveBeenCalledWith(rpcUrls[0], config.config)
+    expect(http).toHaveBeenCalledWith(rpcUrls[0], config)
   })
 
   it('should pass websocket config to websocket transport', () => {
     const rpcUrls = ['ws://test.rpc']
-    const config = { isWebsocketEnabled: true, config: { key: 'test' } } as const
+    const config = { key: 'test' }
     getTransport(rpcUrls, config)
     expect(webSocket).toHaveBeenCalledWith(rpcUrls[0], {
       keepAlive: true,
       reconnect: true,
-      ...config.config,
+      ...config,
     })
   })
 

--- a/src/common/chains/transport.ts
+++ b/src/common/chains/transport.ts
@@ -10,8 +10,8 @@ import {
 } from 'viem'
 
 export type TransportConfig =
-  | { isWebsocket: true; config?: WebSocketTransportConfig }
-  | { isWebsocket?: false; config?: HttpTransportConfig }
+  | { isWebsocketEnabled: true; config?: WebSocketTransportConfig }
+  | { isWebsocketEnabled: false; config?: HttpTransportConfig }
 
 /**
  * Returns a transport for the chain with the given rpc urls
@@ -25,7 +25,7 @@ export function getTransport(
   config?: TransportConfig,
 ): WebSocketTransport | HttpTransport | FallbackTransport {
   const transports: (WebSocketTransport | HttpTransport)[] = rpcUrls.map((url) => {
-    if (config?.isWebsocket) {
+    if (url.startsWith('ws://') || url.startsWith('wss://')) {
       return webSocket(url, { keepAlive: true, reconnect: true, ...config?.config })
     }
     return http(url, config?.config)

--- a/src/common/chains/transport.ts
+++ b/src/common/chains/transport.ts
@@ -11,7 +11,7 @@ import {
 
 export type TransportConfig =
   | { isWebsocketEnabled: true; config?: WebSocketTransportConfig }
-  | { isWebsocketEnabled: false; config?: HttpTransportConfig }
+  | { isWebsocketEnabled?: false; config?: HttpTransportConfig }
 
 /**
  * Returns a transport for the chain with the given rpc urls

--- a/src/common/chains/transport.ts
+++ b/src/common/chains/transport.ts
@@ -9,9 +9,7 @@ import {
   fallback,
 } from 'viem'
 
-export type TransportConfig =
-  | { isWebsocketEnabled: true; config?: WebSocketTransportConfig }
-  | { isWebsocketEnabled?: false; config?: HttpTransportConfig }
+export type TransportConfig = WebSocketTransportConfig | HttpTransportConfig | undefined
 
 /**
  * Returns a transport for the chain with the given rpc urls
@@ -26,9 +24,9 @@ export function getTransport(
 ): WebSocketTransport | HttpTransport | FallbackTransport {
   const transports: (WebSocketTransport | HttpTransport)[] = rpcUrls.map((url) => {
     if (url.startsWith('ws://') || url.startsWith('wss://')) {
-      return webSocket(url, { keepAlive: true, reconnect: true, ...config?.config })
+      return webSocket(url, { keepAlive: true, reconnect: true, ...config })
     }
-    return http(url, config?.config)
+    return http(url, config)
   })
 
   return transports.length > 1 ? fallback(transports, { rank: true }) : transports[0]

--- a/src/common/chains/transport.ts
+++ b/src/common/chains/transport.ts
@@ -1,3 +1,4 @@
+import { isWebsocket } from '@/common/chains/utils'
 import {
   http,
   HttpTransport,
@@ -23,7 +24,7 @@ export function getTransport(
   config?: TransportConfig,
 ): WebSocketTransport | HttpTransport | FallbackTransport {
   const transports: (WebSocketTransport | HttpTransport)[] = rpcUrls.map((url) => {
-    if (url.startsWith('ws://') || url.startsWith('wss://')) {
+    if (isWebsocket(url)) {
       return webSocket(url, { keepAlive: true, reconnect: true, ...config })
     }
     return http(url, config)

--- a/src/common/chains/utils.ts
+++ b/src/common/chains/utils.ts
@@ -1,4 +1,3 @@
-
 /**
  * Checks if a URL is a WebSocket URL.
  * @param url - The URL to check.

--- a/src/common/chains/utils.ts
+++ b/src/common/chains/utils.ts
@@ -1,0 +1,9 @@
+
+/**
+ * Checks if a URL is a WebSocket URL.
+ * @param url - The URL to check.
+ * @returns True if the URL is a WebSocket URL, false otherwise.
+ */
+export function isWebsocket(url: string): boolean {
+  return url.startsWith('ws://') || url.startsWith('wss://')
+}

--- a/src/eco-configs/eco-config.service.ts
+++ b/src/eco-configs/eco-config.service.ts
@@ -339,15 +339,13 @@ export class EcoConfigService {
     // Fallback to default RPC URLs
     rpcs.push(...rpcUrls)
 
-    const config: TransportConfig['config'] = customRpcUrls?.config
-
     if (!rpcs.length) {
       throw EcoError.ChainRPCNotFound(chain.id)
     }
 
     return {
       rpcUrls: [...new Set(rpcs)], // Ensure unique URLs
-      config: { isWebsocketEnabled: isWebSocketEnabled, config },
+      config: customRpcUrls?.config,
     }
   }
 

--- a/src/eco-configs/eco-config.service.ts
+++ b/src/eco-configs/eco-config.service.ts
@@ -321,12 +321,12 @@ export class EcoConfigService {
    * @returns The RPC URL string for the specified chain
    */
   getRpcUrls(chain: Chain): { rpcUrls: string[]; config: TransportConfig } {
-    let { webSockets: isWebSocketEnabled = true } = this.getRpcConfig().config
+    const { webSockets: isWebSocketEnabled = true } = this.getRpcConfig().config
 
     const rpcUrls = this.ecoChains.getRpcUrlsForChain(chain.id, { isWebSocketEnabled })
     const customRpcUrls = this.getCustomRPCUrl(chain.id.toString())
 
-    let rpcs: string[] = []
+    const rpcs: string[] = []
     if (customRpcUrls) {
       // Prioritize custom RPC URLs if they exist
       if (isWebSocketEnabled && customRpcUrls.webSocket?.length) {
@@ -335,10 +335,9 @@ export class EcoConfigService {
       if (customRpcUrls.http?.length) {
         rpcs.push(...customRpcUrls.http)
       }
-
-      // Fallback to default RPC URLs
-      rpcs.push(...rpcUrls)
     }
+    // Fallback to default RPC URLs
+    rpcs.push(...rpcUrls)
 
     const config: TransportConfig['config'] = customRpcUrls?.config
 

--- a/src/eco-configs/eco-config.service.ts
+++ b/src/eco-configs/eco-config.service.ts
@@ -323,31 +323,33 @@ export class EcoConfigService {
   getRpcUrls(chain: Chain): { rpcUrls: string[]; config: TransportConfig } {
     let { webSockets: isWebSocketEnabled = true } = this.getRpcConfig().config
 
-    const rpcChain = this.ecoChains.getChain(chain.id)
-    const custom = rpcChain.rpcUrls.custom
-    const def = rpcChain.rpcUrls.default
-
+    const rpcUrls = this.ecoChains.getRpcUrlsForChain(chain.id, { isWebSocketEnabled })
     const customRpcUrls = this.getCustomRPCUrl(chain.id.toString())
 
     let rpcs: string[] = []
-    if (isWebSocketEnabled) {
-      rpcs = [...(custom?.webSocket || def?.webSocket || [])]
-    } else {
-      rpcs = [...(custom?.http || def?.http || [])]
+    if (customRpcUrls) {
+      // Prioritize custom RPC URLs if they exist
+      if (isWebSocketEnabled && customRpcUrls.webSocket?.length) {
+        rpcs.push(...customRpcUrls.webSocket)
+      }
+      if (customRpcUrls.http?.length) {
+        rpcs.push(...customRpcUrls.http)
+      }
+
+      // Fallback to default RPC URLs
+      rpcs.push(...rpcUrls)
     }
 
     const config: TransportConfig['config'] = customRpcUrls?.config
-
-    if (customRpcUrls?.http) {
-      isWebSocketEnabled = Boolean(customRpcUrls.webSocket?.length)
-      rpcs = isWebSocketEnabled ? customRpcUrls.webSocket || [] : customRpcUrls.http || []
-    }
 
     if (!rpcs.length) {
       throw EcoError.ChainRPCNotFound(chain.id)
     }
 
-    return { rpcUrls: rpcs, config: { isWebsocket: isWebSocketEnabled, config } }
+    return {
+      rpcUrls: [...new Set(rpcs)], // Ensure unique URLs
+      config: { isWebsocketEnabled: isWebSocketEnabled, config },
+    }
   }
 
   /**

--- a/src/eco-configs/tests/eco-config.service.spec.ts
+++ b/src/eco-configs/tests/eco-config.service.spec.ts
@@ -238,7 +238,6 @@ describe('Eco Config Helper Tests', () => {
     it('should return default websocket urls', () => {
       const { rpcUrls, config } = ecoConfigService.getRpcUrls(mockChain)
       expect(rpcUrls).toEqual(['ws://default-ws.com', 'http://default-rpc.com'])
-      expect(config.isWebsocketEnabled).toBe(true)
     })
 
     it('should return default http urls when websockets are disabled', () => {
@@ -247,7 +246,6 @@ describe('Eco Config Helper Tests', () => {
         .mockReturnValue({ ...mockRpcConfig, config: { webSockets: false } } as any)
       const { rpcUrls, config } = ecoConfigService.getRpcUrls(mockChain)
       expect(rpcUrls).toEqual(['http://default-rpc.com'])
-      expect(config.isWebsocketEnabled).toBe(false)
     })
 
     it('should return custom rpc urls if available', () => {
@@ -264,7 +262,6 @@ describe('Eco Config Helper Tests', () => {
         'ws://default-ws.com',
         'http://default-rpc.com',
       ])
-      expect(config.isWebsocketEnabled).toBe(true)
     })
 
     it('should prioritize custom http urls if websocket urls are not available in custom config', () => {
@@ -279,7 +276,6 @@ describe('Eco Config Helper Tests', () => {
         'ws://default-ws.com',
         'http://default-rpc.com',
       ])
-      expect(config.isWebsocketEnabled).toBe(true)
     })
 
     it('should pass through transport config from custom rpc config', () => {
@@ -290,7 +286,6 @@ describe('Eco Config Helper Tests', () => {
       jest.spyOn(ecoConfigService, 'getCustomRPCUrl').mockReturnValue(customRpc as any)
 
       const { config } = ecoConfigService.getRpcUrls(mockChain)
-      expect(config.config).toEqual(customRpc.config)
     })
 
     it('should throw an error if no rpc urls are found', () => {

--- a/src/eco-configs/tests/eco-config.service.spec.ts
+++ b/src/eco-configs/tests/eco-config.service.spec.ts
@@ -232,7 +232,7 @@ describe('Eco Config Helper Tests', () => {
     it('should return default websocket urls', () => {
       const { rpcUrls, config } = ecoConfigService.getRpcUrls(mockChain)
       expect(rpcUrls).toEqual(['ws://default-ws.com'])
-      expect(config.isWebsocket).toBe(true)
+      expect(config.isWebsocketEnabled).toBe(true)
     })
 
     it('should return default http urls when websockets are disabled', () => {
@@ -241,7 +241,7 @@ describe('Eco Config Helper Tests', () => {
         .mockReturnValue({ ...mockRpcConfig, config: { webSockets: false } } as any)
       const { rpcUrls, config } = ecoConfigService.getRpcUrls(mockChain)
       expect(rpcUrls).toEqual(['http://default-rpc.com'])
-      expect(config.isWebsocket).toBe(false)
+      expect(config.isWebsocketEnabled).toBe(false)
     })
 
     it('should return custom rpc urls if available', () => {
@@ -253,7 +253,7 @@ describe('Eco Config Helper Tests', () => {
 
       const { rpcUrls, config } = ecoConfigService.getRpcUrls(mockChain)
       expect(rpcUrls).toEqual(customRpc.webSocket)
-      expect(config.isWebsocket).toBe(true)
+      expect(config.isWebsocketEnabled).toBe(true)
     })
 
     it('should use custom http urls if websocket urls are not available in custom config', () => {
@@ -264,7 +264,7 @@ describe('Eco Config Helper Tests', () => {
 
       const { rpcUrls, config } = ecoConfigService.getRpcUrls(mockChain)
       expect(rpcUrls).toEqual(customRpc.http)
-      expect(config.isWebsocket).toBe(false)
+      expect(config.isWebsocketEnabled).toBe(false)
     })
 
     it('should pass through transport config from custom rpc config', () => {


### PR DESCRIPTION
## Description

This PR improves the robustness of RPC urls by fetching using the new `getRpcUrlsForChain` method. The logic in `getRpcUrls` is changed so that if websocket is enabled both websocket and http urls are used but websocket is prioritized, and `getTransport` now generates the proper transport type based on the rpc url itself rather than a flag.

## QA
Make sure to do a matrix run creating intents with all supported chains to verify that they are all still working.