### PR TITLE
Implement same-chain swap handling in EverclearProviderService

### DIFF
--- a/src/liquidity-manager/services/liquidity-providers/Everclear/everclear-provider.service.spec.ts
+++ b/src/liquidity-manager/services/liquidity-providers/Everclear/everclear-provider.service.spec.ts
@@ -155,6 +155,21 @@ describe('EverclearProviderService', () => {
         EverclearApiError,
       )
     })
+
+    it('should return an empty array if origin and destination chains are the same', async () => {
+      const sameChainTokenOut: TokenData = {
+        ...mockTokenOut,
+        chainId: mockTokenIn.chainId,
+        config: {
+          ...mockTokenOut.config,
+          chainId: mockTokenIn.chainId,
+        },
+      }
+
+      const quotes = await service.getQuote(mockTokenIn, sameChainTokenOut, 100)
+      expect(quotes).toEqual([])
+      expect(fetch).not.toHaveBeenCalled()
+    })
   })
 
   describe('execute', () => {
@@ -259,6 +274,22 @@ describe('EverclearProviderService', () => {
       await expect(service.execute(mockWalletAddress, mockQuote)).rejects.toThrow(
         'Kernel client account or chain is not available.',
       )
+    })
+
+    it('should throw for same-chain swaps', async () => {
+      const sameChainQuote = {
+        ...mockQuote,
+        tokenOut: {
+          ...mockTokenOut,
+          chainId: mockTokenIn.chainId,
+          config: { ...mockTokenOut.config, chainId: mockTokenIn.chainId },
+        },
+      } as any
+
+      await expect(service.execute(mockWalletAddress, sameChainQuote)).rejects.toThrow(
+        'same-chain swaps are not supported',
+      )
+      expect(fetch).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
- Added logic to skip quoting and return an empty array if the origin and destination chains are the same.
- Updated the execute method to throw an error for same-chain swaps, ensuring proper error handling and logging.
- Enhanced unit tests to cover these new scenarios.