### PR TITLE
Whitelist-driven “stranded token” recovery mechanism

### DIFF
--- a/src/eco-configs/eco-config.types.ts
+++ b/src/eco-configs/eco-config.types.ts
@@ -404,6 +404,11 @@ export interface LiquidityManagerConfig {
   walletStrategies: {
     [walletName: string]: Strategy[]
   }
+  // Whitelist of tokens to include as SURPLUS-only (targetBalance=0) per wallet
+  // These tokens will be added to tokensPerWallet so the system can drain them when deficits exist
+  strandedWhitelist?: {
+    tokens: { chainId: number; tokenAddress: Hex }[]
+  }
 }
 
 export interface LiFiConfigType {


### PR DESCRIPTION
### Summary
This PR adds a whitelist-driven “stranded token” recovery mechanism. You can list specific tokens (by chain and address) that the system should treat as surplus-only: they’re added to each scheduled wallet’s supported tokens with targetBalance=0 and minBalance=0, so they’re never rebalanced to, but can be opportunistically used to fund real deficits. Entries are deduplicated against the existing token set, and the feature is a no-op if the whitelist is empty. This reduces manual ops burden from unsupported intermediary tokens that occasionally get stuck after failed flows.

### Config example
```ts
liquidityManager: {
    strandedWhitelist: {
      tokens: [
        { chainId: 1, tokenAddress: '0x12` },
        { chainId: 137, tokenAddress: '0x34` },
      ],
    }
}
```