### PR TITLE
Enable withdrawals for gasless intents

### DIFF
--- a/src/indexer/services/indexer.service.ts
+++ b/src/indexer/services/indexer.service.ts
@@ -18,21 +18,14 @@ export class IndexerService {
     this.config = this.ecoConfigService.getIndexer()
   }
 
-  async getNextBatchWithdrawals(intentSourceAddr?: Hex): Promise<BatchWithdraws[]> {
+  async getNextBatchWithdrawals(
+    intentSourceAddr?: Hex,
+  ): Promise<(BatchWithdraws | BatchWithdrawGasless)[]> {
     const searchParams = { evt_log_address: intentSourceAddr }
-    const data = await this.fetch<(BatchWithdraws | BatchWithdrawGasless)[]>(
+    return await this.fetch<(BatchWithdraws | BatchWithdrawGasless)[]>(
       '/intents/nextBatchWithdrawals',
       { searchParams },
     )
-
-    const withdrawals: BatchWithdraws[] = []
-    data.forEach((record) => {
-      if (!this.isGaslessIntent(record)) {
-        withdrawals.push(record)
-      }
-    })
-
-    return withdrawals
   }
 
   getNextSendBatch(intentSourceAddr?: Hex) {
@@ -62,11 +55,5 @@ export class IndexerService {
       this.logger.error('Indexer: Fetch error', error)
       throw error
     }
-  }
-
-  private isGaslessIntent(
-    record: BatchWithdraws | BatchWithdrawGasless,
-  ): record is BatchWithdrawGasless {
-    return 'intentHash' in record.intent
   }
 }

--- a/src/intent-processor/intent-processor.module.ts
+++ b/src/intent-processor/intent-processor.module.ts
@@ -3,6 +3,7 @@ import { SignModule } from '@/sign/sign.module'
 import { BalanceModule } from '@/balance/balance.module'
 import { TransactionModule } from '@/transaction/transaction.module'
 import { IndexerModule } from '@/indexer/indexer.module'
+import { IntentModule } from '@/intent/intent.module'
 import { IntentProcessorQueue } from '@/intent-processor/queues/intent-processor.queue'
 import { IntentProcessorService } from '@/intent-processor/services/intent-processor.service'
 import { IntentProcessor } from '@/intent-processor/processors/intent.processor'
@@ -13,6 +14,7 @@ import { IntentProcessor } from '@/intent-processor/processors/intent.processor'
     TransactionModule,
     IndexerModule,
     SignModule,
+    IntentModule,
     IntentProcessorQueue.init(),
   ],
   providers: [IntentProcessorService, IntentProcessor],

--- a/src/intent-processor/utils/gasless.ts
+++ b/src/intent-processor/utils/gasless.ts
@@ -1,0 +1,7 @@
+import { BatchWithdraws, BatchWithdrawGasless } from '@/indexer/interfaces/batch-withdraws.interface'
+
+export function isGaslessIntent(
+  record: BatchWithdraws | BatchWithdrawGasless,
+): record is BatchWithdrawGasless {
+  return 'intentHash' in record.intent
+}

--- a/src/intent/repositories/intent-source.repository.ts
+++ b/src/intent/repositories/intent-source.repository.ts
@@ -31,6 +31,16 @@ export class IntentSourceRepository {
     return this.queryIntents({ 'intent.intentGroupID': intentGroupID }, projection)
   }
 
+  async getIntentsByHashes(
+    hashes: string[],
+    projection: object = {},
+  ): Promise<IntentSourceModel[]> {
+    if (hashes.length === 0) {
+      return []
+    }
+    return this.queryIntents({ 'intent.hash': { $in: hashes } }, projection)
+  }
+
   async createIntentFromIntentInitiation(
     intentGroupID: string,
     quoteID: string,


### PR DESCRIPTION
## Summary
- Added support for processing gasless intent withdrawals alongside regular intents
- Implemented efficient batch querying for gasless intent data from MongoDB
- Created shared utility function for identifying gasless intents

## Changes
- **New utility function**: Created `isGaslessIntent` in `/src/intent-processor/utils/gasless.ts` to identify gasless intents
- **IndexerService update**: Modified `getNextBatchWithdrawals()` to return both regular and gasless intents without filtering
- **Repository enhancement**: Added `getIntentsByHashes()` method to `IntentSourceRepository` for efficient batch queries
- **IntentProcessorService update**: Enhanced to handle gasless intents by fetching full data from MongoDB and processing them alongside regular intents
- **Module dependencies**: Added `IntentModule` to `IntentProcessorModule` for repository access

## Test Plan
- [ ] Verify regular intent withdrawals continue to work as expected
- [ ] Test gasless intent withdrawals are properly processed
- [ ] Confirm batch queries to MongoDB are working efficiently
- [ ] Validate that gasless intents with missing data are properly handled and logged

🤖 Generated with [Claude Code](https://claude.ai/code)